### PR TITLE
[WIP] prefer elasticsearch6-dsl to elasticsearch-dsl

### DIFF
--- a/.github/workflows/test_djelme.yml
+++ b/.github/workflows/test_djelme.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -36,7 +36,7 @@ jobs:
           - {python: '3.7', django: '4.1'}
           - {python: '3.10', django: '1.11'}
           - {python: '3.10', django: '2.0'}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       elasticsearch:
         image: elasticsearch:6.8.23

--- a/.github/workflows/test_djelme.yml
+++ b/.github/workflows/test_djelme.yml
@@ -12,8 +12,8 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         id: setup-py
         with:
           python-version: '3.7'
@@ -43,8 +43,8 @@ jobs:
         ports:
           - 9201:9200
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         id: setup-py
         with:
           python-version: ${{ matrix.python }}

--- a/elasticsearch_metrics/apps.py
+++ b/elasticsearch_metrics/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 from django.conf import settings
-from elasticsearch_dsl.connections import connections
+from elasticsearch6_dsl.connections import connections
 from django.utils.module_loading import autodiscover_modules
 
 

--- a/elasticsearch_metrics/field.py
+++ b/elasticsearch_metrics/field.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from elasticsearch_dsl import field as edsl_field
+from elasticsearch6_dsl import field as edsl_field
 
 __all__ = ["Date"]
 # Expose all fields from elasticsearch_dsl.field

--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -4,7 +4,7 @@ import logging
 from django.apps import apps
 from django.conf import settings
 from django.utils import timezone
-from elasticsearch.exceptions import NotFoundError
+from elasticsearch6.exceptions import NotFoundError
 from elasticsearch6_dsl import Document, connections
 from elasticsearch6_dsl.document import IndexMeta, MetaField
 from elasticsearch6_dsl.index import Index

--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -5,9 +5,9 @@ from django.apps import apps
 from django.conf import settings
 from django.utils import timezone
 from elasticsearch.exceptions import NotFoundError
-from elasticsearch_dsl import Document, connections
-from elasticsearch_dsl.document import IndexMeta, MetaField
-from elasticsearch_dsl.index import Index
+from elasticsearch6_dsl import Document, connections
+from elasticsearch6_dsl.document import IndexMeta, MetaField
+from elasticsearch6_dsl.index import Index
 
 from elasticsearch_metrics import signals
 from elasticsearch_metrics import exceptions

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "metrics",
         "statistics",
     ),
-    install_requires=["elasticsearch-dsl>=6.3.0,<7.0.0"],
+    install_requires=["elasticsearch6-dsl>=6.3.0,<7.0.0"],
     extras_require=EXTRAS_REQUIRE,
     classifiers=[
         "Operating System :: OS Independent",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 
-from elasticsearch_dsl import connections
+from elasticsearch6_dsl import connections
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,7 +3,7 @@ import pytest
 import datetime as dt
 from django.utils import timezone
 from elasticsearch_metrics import metrics
-from elasticsearch_dsl import (
+from elasticsearch6_dsl import (
     IndexTemplate,
     analyzer,
     tokenizer,


### PR DESCRIPTION
`djelme` requires `elasticsearch-dsl>=6.30<=7.00` which means it can't be installed in projects that require a different version of `es-dsl` (cough, cough, osf.io). Complicating matters, the major version of `es-dsl` **should** match the version of `es` being interacted with.

As at least a temporary workaround, I've changed the dep to `elasticsearch6-dsl` and updated imports to import from `elasticsearch6_dsl`.  I haven't actually confirmed that it works *properly*, but it does at least install, so that's something.