### PR TITLE
[CR] fix github actions build / test

### DIFF
--- a/.github/workflows/test_djelme.yml
+++ b/.github/workflows/test_djelme.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -36,7 +36,7 @@ jobs:
           - {python: '3.7', django: '4.1'}
           - {python: '3.10', django: '1.11'}
           - {python: '3.10', django: '2.0'}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       elasticsearch:
         image: elasticsearch:6.8.23

--- a/.github/workflows/test_djelme.yml
+++ b/.github/workflows/test_djelme.yml
@@ -12,8 +12,8 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         id: setup-py
         with:
           python-version: '3.7'
@@ -43,8 +43,8 @@ jobs:
         ports:
           - 9201:9200
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         id: setup-py
         with:
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
Github actions breaks because:

> There's no py3.6 on ubuntu22 combo available, so pin ubuntu to v20 which has all pythons.

Also update the versions of the actions to their most recent versions. Neither bump had breaking changes.
* `checkout`: `v3` => `v4`
* `setup-python`: `v4` => `v5`

