### PR TITLE
Update matrix for workflow

### DIFF
--- a/.github/workflows/test_djelme.yml
+++ b/.github/workflows/test_djelme.yml
@@ -28,15 +28,21 @@ jobs:
       matrix:
         python: ['3.6', '3.7', '3.8', '3.9', '3.10']
         django: ['1.11', '2.0', '2.1', '2.2', '3.0', '3.1', '3.2', '4.0', '4.1']
+        os: ['ubuntu-latest', 'ubuntu-20.04']
         # TODO: elasticsearch: ['6', '7', '8', '9']
         exclude:
+          - {os: 'ubuntu-20.04', python: '3.7'}
+          - {os: 'ubuntu-20.04', python: '3.8'}
+          - {os: 'ubuntu-20.04', python: '3.9'}
+          - {os: 'ubuntu-20.04', python: '3.10'}
+          - {os: 'ubuntu-latest', python: '3.6'}
           - {python: '3.6', django: '4.0'}
           - {python: '3.6', django: '4.1'}
           - {python: '3.7', django: '4.0'}
           - {python: '3.7', django: '4.1'}
           - {python: '3.10', django: '1.11'}
           - {python: '3.10', django: '2.0'}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     services:
       elasticsearch:
         image: elasticsearch:6.8.23


### PR DESCRIPTION
Change the matrix since Python 3.6 is not available on ubuntu-22.04

https://github.com/actions/setup-python/issues/544#issuecomment-1332535877