### PR TITLE
[ENG-9696] timeseries search

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,5 +105,5 @@ pc up testbox
 
 example devloop -- build with current code, lint and run tests with debugger on error, stop on failure
 ```
-pc run --build --rm --no-deps testbox poetry run python -m elasticsearch_metrics.tests --devloop
+pc run --build --rm --no-deps testbox poetry run python -m elasticsearch_metrics.tests --failfast --pdb
 ```

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ from elasticsearch_metrics.imps.elastic8 import EventRecord
 class UsageRecord(EventRecord):
     item_id: int
 
-    class Meta:
-        djelme_backend = "my-es8-backend"  # optional if only one backend
+    class Index:
+        using = "my-es8-backend"  # optional if only one backend
 ```
 
 Either enable autosetup...
@@ -87,8 +87,13 @@ UsageRecord.record(item_id='my.item.id')
 Go forth and search!
 
 ```python
-# search across all timeseries indexes -- get an `elasticsearch8.dsl.Search` object
+# get an instance of `elasticsearch8.dsl.Search` that queries all timeseries indexes of this type:
 UsageRecord.search()
+
+# or get a `Search` for a given time range (from_when <= timestamp < until_when)
+UsageRecord.search_timeseries_range((1999,), (2001,))  # in or after 1999; before 2001
+UsageRecord.search_timeseries_range((2050, 12), (2051,))  # in 2050-12
+UsageRecord.search_timeseries_range(datetime.date(2030, 1, 1), datetime.date(2030, 2, 1))  # in 2030-01
 ```
 
 ## Timeseries indexes

--- a/elasticsearch_metrics/apps.py
+++ b/elasticsearch_metrics/apps.py
@@ -57,10 +57,7 @@ def _each_backend_setting() -> (
             if not (
                 isinstance(_imp_module_name, str)
                 and isinstance(_imp_kwargs, dict)
-                and all(
-                    isinstance(_k, str) and isinstance(_v, str)
-                    for _k, _v in _imp_kwargs.items()
-                )
+                and all(isinstance(_k, str) for _k in _imp_kwargs.keys())
             ):
                 raise ImproperlyConfigured(
                     BACKENDS_SETTING,

--- a/elasticsearch_metrics/apps.py
+++ b/elasticsearch_metrics/apps.py
@@ -2,12 +2,10 @@ import collections
 
 from django.apps import AppConfig
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import autodiscover_modules
 
 from elasticsearch_metrics.registry import djelme_registry
 
-BACKENDS_SETTING = "DJELME_BACKENDS"
 AUTOSETUP_SETTING = "DJELME_AUTOSETUP"
 
 
@@ -17,14 +15,15 @@ class ElasticsearchMetricsConfig(AppConfig):
     def ready(self) -> None:
         # load backends settings
         _backend_names_by_module = collections.defaultdict(list)
-        for _backend_name, _imp_module_name, _imp_kwargs in _each_backend_setting():
+        for (
+            _backend_name,
+            _imp_module_name,
+            _,
+        ) in djelme_registry.each_backend_settings():
             _backend_names_by_module[_imp_module_name].append(_backend_name)
-            djelme_registry.register_backend(
-                _backend_name, _imp_module_name, _imp_kwargs
-            )
         # discover any `foo.metrics` in installed apps
         autodiscover_modules("metrics")
-        # call `djelme_when_ready` on each imp module
+        # call `djelme_when_ready` for each imp module (only once)
         for _imp_module_name, _backend_names in _backend_names_by_module.items():
             _imp_module = djelme_registry.get_imp_module(_imp_module_name)
             _imp_module.djelme_when_ready(
@@ -39,28 +38,3 @@ class ElasticsearchMetricsConfig(AppConfig):
                 _recordtypes,
             ) in djelme_registry.each_recordtype_by_backend():
                 djelme_registry.get_backend(_backend_name).djelme_setup(_recordtypes)
-
-
-###
-# accessing django settings
-
-
-def _each_backend_setting() -> (
-    collections.abc.Iterator[tuple[str, str, dict[str, str]]]
-):
-    for _backend_name, _backend_imps in getattr(settings, BACKENDS_SETTING, {}).items():
-        if len(_backend_imps) > 1:
-            raise ImproperlyConfigured(
-                BACKENDS_SETTING, "only one imp per backend, at the moment"
-            )
-        for _imp_module_name, _imp_kwargs in _backend_imps.items():
-            if not (
-                isinstance(_imp_module_name, str)
-                and isinstance(_imp_kwargs, dict)
-                and all(isinstance(_k, str) for _k in _imp_kwargs.keys())
-            ):
-                raise ImproperlyConfigured(
-                    BACKENDS_SETTING,
-                    'expected {"mybackend": {"imp.path": {"imp_config": "..."}}}',
-                )
-            yield (_backend_name, _imp_module_name, _imp_kwargs)

--- a/elasticsearch_metrics/imps/elastic6.py
+++ b/elasticsearch_metrics/imps/elastic6.py
@@ -252,13 +252,20 @@ class BaseMetric(metaclass=MetricMeta):
         )
 
     @classmethod
+    def get_timeseries_name_prefix(cls) -> str:
+        return ""
+
+    @classmethod
     def get_index_name(cls, date: datetime.date | None = None) -> str:
         date = date or timezone.now().date()
         dateformat = getattr(
             settings, "ELASTICSEARCH_METRICS_DATE_FORMAT", DEFAULT_DATE_FORMAT
         )
         date_formatted = date.strftime(dateformat)
-        return "{}_{}".format(cls._template_name, date_formatted)
+        _name_parts = (cls._template_name, date_formatted)
+        if _prefix := cls.get_timeseries_name_prefix():
+            _name_parts = (_prefix, *_name_parts)
+        return "_".join(_name_parts)
 
 
 class Metric(Document, BaseMetric):

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -158,28 +158,12 @@ class DjelmeRecordtype(esdsl.Document, metaclass=_DjelmeRecordtypeMetaclass):
 
     @classmethod
     def check_djelme_setup(cls, using: str | None = None) -> bool:
+        # this base class has only a single index -- does it exist?
         return bool(cls._index.get(using=using))
 
     @classmethod
-    def refresh_timeseries_indexes(cls, using: str | None = None) -> None:
-        cls._get_connection(using).indices.refresh(
-            index=cls.format_timeseries_index_pattern()
-        )
-
-    @classmethod
-    def each_timeseries_index(
-        cls, using: str | None = None
-    ) -> collections.abc.Iterator[tuple[str, dict[str, typing.Any]]]:
-        _resp = cls._get_connection(using).indices.get(
-            index=cls.format_timeseries_index_pattern(),
-        )
-        for _index_name, _index_info in _resp.items():
-            assert isinstance(_index_name, str)
-            assert isinstance(_index_info, dict)
-            yield _index_name, _index_info
-
-    @classmethod
     def _djelme_teardown(cls, es_client):
+        # this base class has only a single index -- delete it
         cls._index.delete(using=es_client)
 
     @classmethod
@@ -263,13 +247,12 @@ class TimeseriesRecord(DjelmeRecordtype):
 
     @classmethod
     def init(cls, index=None, using=None) -> None:
-        """Create the index and populate the mappings in elasticsearch.
+        """Create an index template with mappings for timeseries indexes
 
         overrides elasticsearch.Document.init
+        (but doesn't call super().init(), which would create a "now" index)
         """
         assert not cls.is_abstract
-        # to init timeseries indexes, create only the template
-        # (don't call super().init(), which would create a "now" index)
         cls.sync_index_template(using=using)
 
     @classmethod
@@ -296,6 +279,24 @@ class TimeseriesRecord(DjelmeRecordtype):
             }
         )
         return cls.search(index=_index_pattern).filter(_timestamp_q)
+
+    @classmethod
+    def refresh_timeseries_indexes(cls, using: str | None = None) -> None:
+        cls._get_connection(using).indices.refresh(
+            index=cls.format_timeseries_index_pattern()
+        )
+
+    @classmethod
+    def each_timeseries_index(
+        cls, using: str | None = None
+    ) -> collections.abc.Iterator[tuple[str, dict[str, typing.Any]]]:
+        _resp = cls._get_connection(using).indices.get(
+            index=cls.format_timeseries_index_pattern(),
+        )
+        for _index_name, _index_info in _resp.items():
+            assert isinstance(_index_name, str)
+            assert isinstance(_index_info, dict)
+            yield _index_name, _index_info
 
     @classmethod
     def _djelme_teardown(cls, es8_client: Elastic8Client) -> None:

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -26,15 +26,7 @@ import django
 from django.conf import settings
 from elasticsearch8.exceptions import NotFoundError
 from elasticsearch8 import Elasticsearch as Elastic8Client
-from elasticsearch8.dsl import (
-    Document,
-    connections,
-    ComposableIndexTemplate,
-    mapped_field,
-    Keyword,
-)
-from elasticsearch8.dsl._sync.document import IndexMeta
-from elasticsearch8.dsl.document_base import DocumentOptions
+from elasticsearch8 import dsl as esdsl
 
 from elasticsearch_metrics import signals
 from elasticsearch_metrics import exceptions
@@ -55,11 +47,11 @@ _DEFAULT_TIMEDEPTH = 3  # xxxx_xx_xx_ (daily)
 # invasive hacky changes to elasticsearch8.dsl
 
 # change default mapping for `str` annotations from Text to Keyword:
-DocumentOptions.type_annotation_map[str] = (Keyword, {})
+esdsl.document_base.DocumentOptions.type_annotation_map[str] = (esdsl.Keyword, {})
 
 
 # changes to document metaclass behavior
-class _DjelmeRecordtypeMetaclass(IndexMeta):
+class _DjelmeRecordtypeMetaclass(esdsl._sync.document.IndexMeta):
     """Metaclass for the base `DjelmeRecordtype` class.
 
     overrides behavior in elasticsearch-py's `IndexMeta` to allow
@@ -117,7 +109,7 @@ class _DjelmeRecordtypeMetaclass(IndexMeta):
         return djelme_registry.get_recordtype_app_label(self)
 
 
-class DjelmeRecordtype(Document, metaclass=_DjelmeRecordtypeMetaclass):
+class DjelmeRecordtype(esdsl.Document, metaclass=_DjelmeRecordtypeMetaclass):
     """a subclass of elasticsearch8.dsl.Document, with conveniences
 
     >>> class MyAbstractRecord(DjelmeRecordtype):
@@ -145,7 +137,7 @@ class DjelmeRecordtype(Document, metaclass=_DjelmeRecordtypeMetaclass):
     """
 
     UNIQUE_TOGETHER_FIELDS: typing.ClassVar[collections.abc.Iterable[str]] = ()
-    unique_id: str = mapped_field(Keyword(), default="")  # filled on save
+    unique_id: str = esdsl.mapped_field(esdsl.Keyword(), default="")  # filled on save
 
     class Meta:
         abstract = True
@@ -229,7 +221,7 @@ class DjelmeRecordtype(Document, metaclass=_DjelmeRecordtypeMetaclass):
 
 
 class TimeseriesRecord(DjelmeRecordtype):
-    timestamp: datetime.datetime = mapped_field(
+    timestamp: datetime.datetime = esdsl.mapped_field(
         default_factory=lambda: django.utils.timezone.now()
     )
 
@@ -251,6 +243,24 @@ class TimeseriesRecord(DjelmeRecordtype):
         return super().init(
             index=(index or cls.format_timeseries_index_name()),
             using=cls._get_using(using),
+        )
+
+    @classmethod
+    def search_timespan(
+        cls,
+        from_when: tuple[int, ...] | datetime.date,
+        until_when: tuple[int, ...] | datetime.date,
+        **kwargs: typing.Any,
+    ) -> esdsl.Search:
+        _index_pattern = timeseries_naming.format_index_pattern_for_range(
+            cls.get_timeseries_name_prefix(),
+            cls.get_timeseries_recordtype_name(),
+            from_when,
+            until_when,
+            timedepth=cls.get_timedepth(),
+        )
+        return cls.search(index=_index_pattern).filter(
+            esdsl.query.Range("timestamp", gte=..., lt=...)
         )
 
     @classmethod
@@ -277,7 +287,7 @@ class TimeseriesRecord(DjelmeRecordtype):
         )
 
     @classmethod
-    def get_timeseries_template(cls) -> ComposableIndexTemplate:
+    def get_timeseries_template(cls) -> esdsl.ComposableIndexTemplate:
         return cls._index.as_composable_template(
             template_name=cls.get_timeseries_template_name(),
             pattern=cls.format_timeseries_index_pattern(),
@@ -444,11 +454,11 @@ class CountedUsageRecord(EventRecord):
     """
 
     # for ProtoCountedUsage:
-    platform_iri: str = mapped_field(required=True, default="")
-    database_iri: str = mapped_field(required=True, default="")
-    item_iri: str = mapped_field(required=True, default="")
-    sessionhour_id: str = mapped_field(Keyword(), default="")
-    within_iris: list[str] = mapped_field(Keyword(), default_factory=list)
+    platform_iri: str = esdsl.mapped_field(required=True, default="")
+    database_iri: str = esdsl.mapped_field(required=True, default="")
+    item_iri: str = esdsl.mapped_field(required=True, default="")
+    sessionhour_id: str = esdsl.mapped_field(esdsl.Keyword(), default="")
+    within_iris: list[str] = esdsl.mapped_field(esdsl.Keyword(), default_factory=list)
 
     class Meta:
         abstract = True
@@ -518,7 +528,7 @@ class DjelmeElastic8Backend:
     @property
     def elastic8_client(self) -> Elastic8Client:
         # assumes `connections.configure` was already called
-        return connections.get_connection(self._elastic8dsl_connection_name)
+        return esdsl.connections.get_connection(self._elastic8dsl_connection_name)
 
     @property
     def _elastic8dsl_connection_name(self) -> str:
@@ -556,7 +566,7 @@ djelme_backend = DjelmeElastic8Backend  # for ProtoDjelmeImp
 def djelme_when_ready(  # for ProtoDjelmeImp
     backends: collections.abc.Iterable[ProtoDjelmeBackend],
 ) -> None:
-    connections.configure(
+    esdsl.connections.configure(
         **{
             _backend._elastic8dsl_connection_name: _backend._elastic8dsl_connection_kwargs
             for _backend in backends

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -258,6 +258,13 @@ class TimeseriesRecord(DjelmeRecordtype):
         )
 
     @classmethod
+    def search(cls, *, index=None, **kwargs):
+        return super().search(
+            index=(index or cls.format_timeseries_index_pattern()),
+            **kwargs,
+        )
+
+    @classmethod
     def search_timeseries_range(
         cls,
         from_when: tuple[int, ...] | datetime.date,

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -27,12 +27,16 @@ from django.conf import settings
 from elasticsearch8.exceptions import NotFoundError
 from elasticsearch8 import Elasticsearch as Elastic8Client
 from elasticsearch8 import dsl as esdsl
-from elasticsearch8._sync.document import IndexMeta
+from elasticsearch8.dsl._sync.document import IndexMeta
 
 from elasticsearch_metrics import signals
 from elasticsearch_metrics import exceptions
 from elasticsearch_metrics.registry import djelme_registry
-from elasticsearch_metrics.protocols import ProtoDjelmeBackend, ProtoCountedUsage
+from elasticsearch_metrics.protocols import (
+    ProtoDjelmeBackend,
+    ProtoCountedUsage,
+    ProtoDjelmeRecord,
+)
 from elasticsearch_metrics.util import timeseries_naming
 from elasticsearch_metrics.util.unique_together import get_unique_id
 from elasticsearch_metrics.util.anon_enough import opaque_sessionhour_id
@@ -144,14 +148,16 @@ class DjelmeRecordtype(esdsl.Document, metaclass=_DjelmeRecordtypeMetaclass):
         abstract = True
 
     @classmethod
-    def record(cls, *, using=None, **kwargs):
+    def record(
+        cls, *, using: str | None = None, **kwargs: typing.Any
+    ) -> "typing.Self":  # typing.Self added in py 3.11 -- str annotation until 3.10 eol
         """Persist a record in Elasticsearch."""
         _instance = cls(**kwargs)
         _instance.save(using=using)
         return _instance
 
     @classmethod
-    def check_djelme_setup(cls, using: str | Elastic8Client | None = None) -> bool:
+    def check_djelme_setup(cls, using: str | None = None) -> bool:
         return bool(cls._index.get(using=using))
 
     @classmethod
@@ -225,7 +231,11 @@ class TimeseriesRecord(DjelmeRecordtype):
     timestamp: datetime.datetime = esdsl.mapped_field(
         default_factory=lambda: django.utils.timezone.now()
     )
-    timeparts: str = esdsl.mapped_field(esdsl.Version())
+    # the 'version' field type allows range queries on semver-like strings
+    # that fit perfectly with "timeparts" representation of a UTC datetime
+    # as a sequence of integers -- helps to avoid time zones and date math
+    # (e.g. '2000' < '2000.5.10' < '2000.5.20.20.20' < '2000.11' < '2001')
+    timestamp_parts: str = esdsl.mapped_field(esdsl.Version(), default="")
 
     class Meta:
         abstract = True
@@ -253,11 +263,16 @@ class TimeseriesRecord(DjelmeRecordtype):
         from_when: tuple[int, ...] | datetime.date,
         until_when: tuple[int, ...] | datetime.date,
         **kwargs: typing.Any,
-    ) -> esdsl.Search:
+    ) -> typing.Any:
         _index_pattern = cls.format_timeseries_index_pattern_for_range(
             from_when, until_when
         )
-        _timestamp_q = esdsl.query.Range("timestamp", gte=..., lt=...)
+        _timedepth = cls.get_timedepth()
+        _timestamp_q = esdsl.query.Range(
+            "timestamp_parts",
+            gte=timeseries_naming.semverlike_timeparts(from_when, timedepth=_timedepth),
+            lt=timeseries_naming.semverlike_timeparts(until_when, timedepth=_timedepth),
+        )
         return cls.search(index=_index_pattern).filter(_timestamp_q)
 
     @classmethod
@@ -425,6 +440,13 @@ class TimeseriesRecord(DjelmeRecordtype):
     ###
     # instance methods
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.timestamp_parts = self._build_timestamp_parts()
+
+    def _build_timestamp_parts(self) -> str:
+        return timeseries_naming.full_semverlike_timeparts(self.timestamp)
+
     def djelme_index_name(self) -> str:
         assert self.timestamp is not None
         return self.format_timeseries_index_name(self.timestamp)
@@ -567,6 +589,7 @@ if __debug__ and typing.TYPE_CHECKING:
     # for static type-checking; verify intent
     _: type[ProtoCountedUsage] = CountedUsageRecord
     __: type[ProtoDjelmeBackend] = DjelmeElastic8Backend
+    ___: type[ProtoDjelmeRecord] = DjelmeRecordtype
 
 ###
 # names expected by ProtoDjelmeImp

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -161,13 +161,13 @@ class DjelmeRecordtype(esdsl.Document, metaclass=_DjelmeRecordtypeMetaclass):
         return bool(cls._index.get(using=using))
 
     @classmethod
-    def refresh_all(cls, using: str | None = None) -> None:
+    def refresh_timeseries_indexes(cls, using: str | None = None) -> None:
         cls._get_connection(using).indices.refresh(
             index=cls.format_timeseries_index_pattern()
         )
 
     @classmethod
-    def each_index(
+    def each_timeseries_index(
         cls, using: str | None = None
     ) -> collections.abc.Iterator[tuple[str, dict[str, typing.Any]]]:
         _resp = cls._get_connection(using).indices.get(
@@ -289,11 +289,10 @@ class TimeseriesRecord(DjelmeRecordtype):
         _index_pattern = cls.format_timeseries_index_pattern_for_range(
             from_when, until_when
         )
-        _timedepth = cls.get_timedepth()
         _timestamp_q = esdsl.query.Range(
             timestamp_parts={
-                "gte": timeseries_naming.semverlike_timeparts(from_when, _timedepth),
-                "lt": timeseries_naming.semverlike_timeparts(until_when, _timedepth),
+                "gte": timeseries_naming.full_semverlike_timeparts(from_when),
+                "lt": timeseries_naming.full_semverlike_timeparts(until_when),
             }
         )
         return cls.search(index=_index_pattern).filter(_timestamp_q)

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -27,6 +27,7 @@ from django.conf import settings
 from elasticsearch8.exceptions import NotFoundError
 from elasticsearch8 import Elasticsearch as Elastic8Client
 from elasticsearch8 import dsl as esdsl
+from elasticsearch8._sync.document import IndexMeta
 
 from elasticsearch_metrics import signals
 from elasticsearch_metrics import exceptions
@@ -51,7 +52,7 @@ esdsl.document_base.DocumentOptions.type_annotation_map[str] = (esdsl.Keyword, {
 
 
 # changes to document metaclass behavior
-class _DjelmeRecordtypeMetaclass(esdsl._sync.document.IndexMeta):
+class _DjelmeRecordtypeMetaclass(IndexMeta):
     """Metaclass for the base `DjelmeRecordtype` class.
 
     overrides behavior in elasticsearch-py's `IndexMeta` to allow
@@ -224,6 +225,7 @@ class TimeseriesRecord(DjelmeRecordtype):
     timestamp: datetime.datetime = esdsl.mapped_field(
         default_factory=lambda: django.utils.timezone.now()
     )
+    timeparts: str = esdsl.mapped_field(esdsl.Version())
 
     class Meta:
         abstract = True
@@ -246,22 +248,17 @@ class TimeseriesRecord(DjelmeRecordtype):
         )
 
     @classmethod
-    def search_timespan(
+    def search_timeseries_range(
         cls,
         from_when: tuple[int, ...] | datetime.date,
         until_when: tuple[int, ...] | datetime.date,
         **kwargs: typing.Any,
     ) -> esdsl.Search:
-        _index_pattern = timeseries_naming.format_index_pattern_for_range(
-            cls.get_timeseries_name_prefix(),
-            cls.get_timeseries_recordtype_name(),
-            from_when,
-            until_when,
-            timedepth=cls.get_timedepth(),
+        _index_pattern = cls.format_timeseries_index_pattern_for_range(
+            from_when, until_when
         )
-        return cls.search(index=_index_pattern).filter(
-            esdsl.query.Range("timestamp", gte=..., lt=...)
-        )
+        _timestamp_q = esdsl.query.Range("timestamp", gte=..., lt=...)
+        return cls.search(index=_index_pattern).filter(_timestamp_q)
 
     @classmethod
     def _djelme_teardown(cls, es8_client: Elastic8Client) -> None:
@@ -320,6 +317,20 @@ class TimeseriesRecord(DjelmeRecordtype):
             recordtype=cls.get_timeseries_recordtype_name(),
             timeparts=timeparts,
             max_timedepth=cls.get_timedepth(),
+        )
+
+    @classmethod
+    def format_timeseries_index_pattern_for_range(
+        cls,
+        from_when: tuple[int, ...] | datetime.date,
+        until_when: tuple[int, ...] | datetime.date,
+    ) -> str:
+        return timeseries_naming.format_index_pattern_for_range(
+            cls.get_timeseries_name_prefix(),
+            cls.get_timeseries_recordtype_name(),
+            from_when,
+            until_when,
+            timedepth=cls.get_timedepth(),
         )
 
     @classmethod
@@ -467,9 +478,9 @@ class CountedUsageRecord(EventRecord):
     def record(
         cls,
         *,
-        # each usage record needs a sessionhour_id -- for migrating old data, can set explicitly
+        # each usage record needs a sessionhour_id -- for migrating old data, can set explicitly...
         sessionhour_id: str = "",
-        # ...but when saving new data, give either the dirty identifying strings
+        # ...but when saving new data, give either the dirty identifying strings:
         user_id: str = "",
         session_id: str = "",
         request_host: str = "",

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -161,6 +161,24 @@ class DjelmeRecordtype(esdsl.Document, metaclass=_DjelmeRecordtypeMetaclass):
         return bool(cls._index.get(using=using))
 
     @classmethod
+    def refresh_all(cls, using: str | None = None) -> None:
+        cls._get_connection(using).indices.refresh(
+            index=cls.format_timeseries_index_pattern()
+        )
+
+    @classmethod
+    def each_index(
+        cls, using: str | None = None
+    ) -> collections.abc.Iterator[tuple[str, dict[str, typing.Any]]]:
+        _resp = cls._get_connection(using).indices.get(
+            index=cls.format_timeseries_index_pattern(),
+        )
+        for _index_name, _index_info in _resp.items():
+            assert isinstance(_index_name, str)
+            assert isinstance(_index_info, dict)
+            yield _index_name, _index_info
+
+    @classmethod
     def _djelme_teardown(cls, es_client):
         cls._index.delete(using=es_client)
 
@@ -244,18 +262,15 @@ class TimeseriesRecord(DjelmeRecordtype):
     # class methods
 
     @classmethod
-    def init(cls, index=None, using=None):
+    def init(cls, index=None, using=None) -> None:
         """Create the index and populate the mappings in elasticsearch.
 
         overrides elasticsearch.Document.init
         """
         assert not cls.is_abstract
         # to init timeseries indexes, create only the template
+        # (don't call super().init(), which would create a "now" index)
         cls.sync_index_template(using=using)
-        return super().init(
-            index=(index or cls.format_timeseries_index_name()),
-            using=cls._get_using(using),
-        )
 
     @classmethod
     def search(cls, *, index=None, **kwargs):
@@ -276,9 +291,10 @@ class TimeseriesRecord(DjelmeRecordtype):
         )
         _timedepth = cls.get_timedepth()
         _timestamp_q = esdsl.query.Range(
-            "timestamp_parts",
-            gte=timeseries_naming.semverlike_timeparts(from_when, timedepth=_timedepth),
-            lt=timeseries_naming.semverlike_timeparts(until_when, timedepth=_timedepth),
+            timestamp_parts={
+                "gte": timeseries_naming.semverlike_timeparts(from_when, _timedepth),
+                "lt": timeseries_naming.semverlike_timeparts(until_when, _timedepth),
+            }
         )
         return cls.search(index=_index_pattern).filter(_timestamp_q)
 

--- a/elasticsearch_metrics/protocols.py
+++ b/elasticsearch_metrics/protocols.py
@@ -44,14 +44,12 @@ class ProtoDjelmeBackend(typing.Protocol):
 class ProtoDjelmeRecord(typing.Protocol):
     @classmethod
     def record(
-        cls, **kwargs: typing.Any
+        cls, *, using: str | None = None, **kwargs: typing.Any
     ) -> "typing.Self":  # typing.Self added in py 3.11 -- str annotation until 3.10 eol
         ...
 
     @classmethod
     def check_djelme_setup(cls, using: str | None = None) -> bool: ...
-
-    def djelme_index_name(self) -> str: ...
 
     @classmethod
     def search_timeseries_range(
@@ -63,6 +61,8 @@ class ProtoDjelmeRecord(typing.Protocol):
 
     # @classmethod
     # def each_timeseries_index_status(cls) -> collections.abc.Iterable[str]: ...
+
+    def djelme_index_name(self) -> str: ...
 
 
 ###

--- a/elasticsearch_metrics/protocols.py
+++ b/elasticsearch_metrics/protocols.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import collections
+import datetime
 import typing
 
 __all__ = (
@@ -53,7 +54,7 @@ class ProtoDjelmeRecord(typing.Protocol):
     def djelme_index_name(self) -> str: ...
 
     @classmethod
-    def search_timespan(
+    def search_timeseries_range(
         cls,
         from_when: tuple[int, ...] | datetime.date,
         until_when: tuple[int, ...] | datetime.date,

--- a/elasticsearch_metrics/protocols.py
+++ b/elasticsearch_metrics/protocols.py
@@ -52,14 +52,13 @@ class ProtoDjelmeRecord(typing.Protocol):
 
     def djelme_index_name(self) -> str: ...
 
-    # TODO: ENG-9696
-    # @classmethod
-    # def search_timespan(
-    #     cls,
-    #     from_when: tuple[int, ...] | datetime.date,
-    #     until_when: tuple[int, ...] | datetime.date,
-    #     **kwargs: typing.Any,
-    # ) -> typing.Any: ...
+    @classmethod
+    def search_timespan(
+        cls,
+        from_when: tuple[int, ...] | datetime.date,
+        until_when: tuple[int, ...] | datetime.date,
+        **kwargs: typing.Any,
+    ) -> typing.Any: ...
 
     # @classmethod
     # def each_timeseries_index_status(cls) -> collections.abc.Iterable[str]: ...

--- a/elasticsearch_metrics/registry.py
+++ b/elasticsearch_metrics/registry.py
@@ -255,10 +255,6 @@ class _DjelmeRegistry:
             )
         return self.all_recordtypes[app_label]
 
-    def _is_type_downstream_of_module(self, given_type: type, module_name: str) -> bool:
-        _upstream_modules = (_cls.__module__ for _cls in given_type.__mro__)
-        return module_name in _upstream_modules
-
 
 def _import_imp_module(imp_module_name: str) -> ProtoDjelmeImp:
     try:

--- a/elasticsearch_metrics/registry.py
+++ b/elasticsearch_metrics/registry.py
@@ -1,9 +1,12 @@
 import collections
 import dataclasses
+import functools
 import importlib
 import weakref
 
 from django.apps import apps
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 from elasticsearch_metrics.protocols import (
     ProtoDjelmeBackend,
@@ -13,6 +16,8 @@ from elasticsearch_metrics.protocols import (
 from elasticsearch_metrics.util.django import find_app_label_for_type
 
 __all__ = ("djelme_registry",)
+
+_BACKENDS_SETTING = "DJELME_BACKENDS"
 
 
 @dataclasses.dataclass
@@ -48,19 +53,14 @@ class _DjelmeRegistry:
 
     # nested mapping from backend_name => imp_module_name => imp backend config dictionary
     # (note, only one imp module allowed per backend (for now))
-    all_backends: dict[str, dict[str, dict[str, str]]] = dataclasses.field(
-        default_factory=dict,
-    )
+    @functools.cached_property
+    def all_backends(self) -> dict[str, dict[str, dict[str, str]]]:
+        _backends_setting = getattr(settings, _BACKENDS_SETTING, {})
+        _validate_backends_setting(_backends_setting)
+        return _backends_setting
 
     ###
     # `register` methods: for adding items to the registry
-
-    def register_backend(
-        self, backend_name: str, imp_module_name: str, imp_kwargs: dict[str, str]
-    ) -> None:
-        if backend_name in self.all_backends:
-            raise RuntimeError(f"duplicate imps named {backend_name!r}")
-        self.all_backends[backend_name] = {imp_module_name: imp_kwargs}
 
     def register_recordtype(
         self,
@@ -186,12 +186,17 @@ class _DjelmeRegistry:
             for _recordtype in self._get_recordtypes_for_app(_app_label).values():
                 yield _recordtype
 
+    def each_backend_settings(self) -> collections.abc.Iterator[tuple[str, str, dict]]:
+        for _backend_name, _imp_config in self.all_backends.items():
+            if _imp_config:
+                _imp_module_name, _imp_kwargs = next(iter(_imp_config.items()))
+                yield (_backend_name, _imp_module_name, _imp_kwargs)
+
     def each_backend_name(
         self,
         *,
         imp_module_name: str = "",
     ) -> collections.abc.Iterator[str]:
-        apps.check_apps_ready()  # ensure django setup done
         for _backend_name, _imp_config in self.all_backends.items():
             if (not imp_module_name) or (imp_module_name in _imp_config):
                 yield _backend_name
@@ -262,6 +267,26 @@ def _import_imp_module(imp_module_name: str) -> ProtoDjelmeImp:
         raise ValueError(f"could not import {imp_module_name!r}") from _error
     assert isinstance(_imp_module, ProtoDjelmeImp)
     return _imp_module
+
+
+def _validate_backends_setting(backends_setting):
+    for _backend_name, _backend_imps in getattr(
+        settings, _BACKENDS_SETTING, {}
+    ).items():
+        if len(_backend_imps) > 1:
+            raise ImproperlyConfigured(
+                _BACKENDS_SETTING, "only one imp per backend, at the moment"
+            )
+        for _imp_module_name, _imp_kwargs in _backend_imps.items():
+            if not (
+                isinstance(_imp_module_name, str)
+                and isinstance(_imp_kwargs, dict)
+                and all(isinstance(_k, str) for _k in _imp_kwargs.keys())
+            ):
+                raise ImproperlyConfigured(
+                    _BACKENDS_SETTING,
+                    'expected {"mybackend": {"imp.path": {"imp_config": "..."}}}',
+                )
 
 
 ###

--- a/elasticsearch_metrics/tests/_test_util.py
+++ b/elasticsearch_metrics/tests/_test_util.py
@@ -2,6 +2,7 @@ from io import StringIO
 from unittest import mock
 import types
 import typing
+import uuid
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
@@ -52,18 +53,29 @@ class RealElasticTestCase(SimpleDjelmeTestCase):
 
     def setUp(self):
         super().setUp()
+        _name_prefix = uuid.uuid4().hex
+        self.enterContext(
+            mock.patch(
+                "elasticsearch_metrics.imps.elastic8.TimeseriesRecord.get_timeseries_name_prefix",
+                return_value=_name_prefix,
+            )
+        )
+        self.enterContext(
+            mock.patch(
+                "elasticsearch_metrics.imps.elastic6.BaseMetric.get_timeseries_name_prefix",
+                return_value=_name_prefix,
+            ),
+        )
         if self.__autosetup_backends:
             self.setup_backends()
 
     def tearDown(self):
-        super().tearDown()
         if self.__autoteardown_backends:
             self.teardown_backends()
+        super().tearDown()
 
     def setup_backends(self):
-        # TODO: prefix index names, avoid collisions across test runs
-        # get settings from elasticsearch_metrics.tests.settings.DJELME_BACKENDS
-        # self.teardown_backends()  # in case any already exist
+        # backends based on settings in django.conf.settings.DJELME_BACKENDS
         for _backend_name, _recordtypes in djelme_registry.each_recordtype_by_backend():
             djelme_registry.get_backend(_backend_name).djelme_setup(_recordtypes)
 

--- a/elasticsearch_metrics/tests/_test_util.py
+++ b/elasticsearch_metrics/tests/_test_util.py
@@ -78,5 +78,5 @@ class MockSaveTestCase(SimpleDjelmeTestCase):
             mock.patch("elasticsearch_metrics.imps.elastic6.Document.save"),
         )
         self.mocked_es8_save = self.enterContext(
-            mock.patch("elasticsearch_metrics.imps.elastic8.Document.save"),
+            mock.patch("elasticsearch_metrics.imps.elastic8.esdsl.Document.save"),
         )

--- a/elasticsearch_metrics/tests/dummy8app/metrics.py
+++ b/elasticsearch_metrics/tests/dummy8app/metrics.py
@@ -12,15 +12,15 @@ class Dummy8Event(djelme.EventRecord):
 
     class Index:
         using = "my_elastic8_events"
-        settings = {"refresh_interval": "0"}  # immediate refresh
 
 
-class Dummy8EventWithExplicitNamePrefix(djelme.EventRecord):
+class Monthly8Event(djelme.EventRecord):
     intenzity: int
 
     class Meta:
         timeseries_name_prefix = "dummy8evenz"
         timeseries_recordtype_name = "eventlog"
+        timedepth = 2
 
     class Index:
         using = "my_elastic8_events"
@@ -28,7 +28,7 @@ class Dummy8EventWithExplicitNamePrefix(djelme.EventRecord):
 
 class ThingHappened(djelme.EventRecord):
     thing_id: str = ""
-    happen_code: str = ""
+    happen_code: str | None = None
     dot_path: str | None = mapped_field(Text(analyzer=dot_path_analyzer), default=None)
     commentary: str | None = mapped_field(Text(), default=None)
 
@@ -38,17 +38,17 @@ class ThingHappened(djelme.EventRecord):
 
     class Meta:
         timeseries_recordtype_name = "happen"
-        timedepth = 1
+        timedepth = 1  # yearly timeseries indexes
 
 
 # TODO: tests using ThingHappeningsReport
 class ThingHappeningsReport(djelme.CyclicRecord):
-    item_id: str
-    item_type: str
+    thing_id: str
+    happen_count: int
 
     class Index:
-        settings = {"refresh_interval": "-1"}
         using = "my_elastic8_reports"
 
     class Meta:
         timeseries_name_prefix = "blarg"
+        timedepth = 2  # monthly timeseries indexes

--- a/elasticsearch_metrics/tests/dummy8app/metrics.py
+++ b/elasticsearch_metrics/tests/dummy8app/metrics.py
@@ -12,6 +12,7 @@ class Dummy8Event(djelme.EventRecord):
 
     class Index:
         using = "my_elastic8_events"
+        settings = {"refresh_interval": "0"}  # immediate refresh
 
 
 class Dummy8EventWithExplicitNamePrefix(djelme.EventRecord):

--- a/elasticsearch_metrics/tests/test_imps_elastic8.py
+++ b/elasticsearch_metrics/tests/test_imps_elastic8.py
@@ -273,8 +273,8 @@ class TestSignals(MockSaveTestCase):
         assert post_save_kwargs["sender"] is ThingHappened
 
 
-class TestCreateAndSearch(RealElasticTestCase, autosetup_djelme_backends=True):
-    def test_create_document(self):
+class TestRealCreate(RealElasticTestCase, autosetup_djelme_backends=True):
+    def test_save(self):
         _thing_id = "12345"
         _happen_code = "zyxwv"
         _doc = ThingHappened(thing_id=_thing_id, happen_code=_happen_code)
@@ -285,6 +285,7 @@ class TestCreateAndSearch(RealElasticTestCase, autosetup_djelme_backends=True):
         )
         assert _fetched_doc
         assert _fetched_doc.timestamp == _doc.timestamp
+        assert _fetched_doc.timestamp_parts == _doc.timestamp_parts
         assert _fetched_doc.thing_id == _doc.thing_id == _thing_id
         assert _fetched_doc.happen_code == _doc.happen_code == _happen_code
 
@@ -296,18 +297,48 @@ class TestCreateAndSearch(RealElasticTestCase, autosetup_djelme_backends=True):
         assert properties["thing_id"] == {"type": "keyword"}
         assert properties["happen_code"] == {"type": "keyword"}
 
-    def test_search(self): ...  # TODO
+    def test_record(self):
+        _thing_id = "54321"
+        _happen_code = "abcde"
+        _doc = ThingHappened.record(thing_id=_thing_id, happen_code=_happen_code)
+        assert _doc.timestamp is not None
+        _fetched_doc = ThingHappened.get(
+            id=_doc.meta.id, index=_doc.djelme_index_name()
+        )
+        assert _fetched_doc
+        assert _fetched_doc.timestamp == _doc.timestamp
+        assert _fetched_doc.timestamp_parts == _doc.timestamp_parts
+        assert _fetched_doc.thing_id == _doc.thing_id == _thing_id
+        assert _fetched_doc.happen_code == _doc.happen_code == _happen_code
 
-
-class TestInit(RealElasticTestCase, autosetup_djelme_backends=False):
-    def test_init(self):
-        ThingHappened.init()
-        name = ThingHappened.format_timeseries_index_name()
+        # index mappings should match the index template
+        name = _doc.djelme_index_name()
         mapping = _es8_client().indices.get_mapping(index=name)
         properties = mapping[name]["mappings"]["properties"]
         assert properties["timestamp"] == {"type": "date"}
         assert properties["thing_id"] == {"type": "keyword"}
         assert properties["happen_code"] == {"type": "keyword"}
+
+
+class TestInit(RealElasticTestCase, autosetup_djelme_backends=False):
+    def test_init(self):
+        ThingHappened.init()
+        _client = _es8_client()
+        _template_name = ThingHappened.get_timeseries_template_name()
+        _index_pattern = ThingHappened.format_timeseries_index_pattern()
+        _template_resp = _client.indices.get_index_template(name=_template_name)
+        (_t_info,) = _template_resp["index_templates"]
+        self.assertEqual(_t_info["name"], _template_name)
+        self.assertEqual(
+            _t_info["index_template"]["index_patterns"],
+            [_index_pattern],
+        )
+        _properties = _t_info["index_template"]["template"]["mappings"]["properties"]
+        self.assertEqual(_properties["timestamp"], {"type": "date"})
+        self.assertEqual(_properties["thing_id"], {"type": "keyword"})
+        self.assertEqual(_properties["happen_code"], {"type": "keyword"})
+        # no indexes; only the template
+        self.assertFalse(list(ThingHappened.each_index()))
 
     def test_check_djelme_setup(self):
         with self.assertRaises(IndexTemplateNotFoundError):
@@ -328,3 +359,58 @@ class TestInit(RealElasticTestCase, autosetup_djelme_backends=False):
 
         ThingHappened.sync_index_template()
         assert ThingHappened.check_djelme_setup() is True
+
+
+class TestDailyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
+    def setUp(self):
+        super().setUp()
+        Dummy8Event.record(timestamp=dt.datetime(1234, 5, 6), intensity=1)
+        Dummy8Event.record(timestamp=dt.datetime(1234, 5, 6, 7), intensity=2)
+        Dummy8Event.record(timestamp=dt.datetime(1234, 5, 7), intensity=3)
+        Dummy8Event.record(timestamp=dt.datetime(1234, 6, 1), intensity=7)
+        Dummy8Event.record(timestamp=dt.datetime(1235, 5, 6), intensity=111)
+        Dummy8Event.record(timestamp=dt.datetime(2345, 6, 9), intensity=11)
+        Dummy8Event.record(timestamp=dt.datetime(2345, 7, 9), intensity=13)
+        Dummy8Event.refresh_all()
+
+    def test_indexes(self):
+        _index_names = {_name for _name, _ in Dummy8Event.each_index()}
+        self.assertEqual(
+            _index_names,
+            {
+                "dummy8app_dummy8event_1234_05_06_",
+                "dummy8app_dummy8event_1234_05_07_",
+                "dummy8app_dummy8event_1234_06_01_",
+                "dummy8app_dummy8event_1235_05_06_",
+                "dummy8app_dummy8event_2345_06_09_",
+                "dummy8app_dummy8event_2345_07_09_",
+            },
+        )
+
+    def test_search(self):
+        def _assert_intens(hits, expected_intensities):
+            _actual = {_hit.intensity for _hit in hits}
+            self.assertEqual(_actual, expected_intensities)
+
+        _assert_intens(
+            Dummy8Event.search(),
+            {1, 2, 3, 7, 11, 13, 111},
+        )
+        _assert_intens(
+            Dummy8Event.search_timeseries_range((1234,), (1235,)),
+            {1, 2, 3, 7},
+        )
+        _assert_intens(
+            Dummy8Event.search_timeseries_range((1233,), (1234,)),
+            set(),
+        )
+        _assert_intens(
+            Dummy8Event.search_timeseries_range(
+                dt.date(1234, 5, 6), dt.date(1234, 5, 7)
+            ),
+            {1, 2},
+        )
+        _assert_intens(
+            Dummy8Event.search_timeseries_range((1234, 6), dt.date(2345, 7, 1)),
+            {7, 111, 11},
+        )

--- a/elasticsearch_metrics/tests/test_imps_elastic8.py
+++ b/elasticsearch_metrics/tests/test_imps_elastic8.py
@@ -423,16 +423,19 @@ class TestDailyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
         Dummy8Event.refresh_timeseries_indexes()
 
     def test_indexes(self):
-        _index_names = {_name for _name, _ in Dummy8Event.each_timeseries_index()}
+        _index_names = {
+            _strip_test_prefix(_name)
+            for _name, _ in Dummy8Event.each_timeseries_index()
+        }
         self.assertEqual(
             _index_names,
             {
-                "dummy8app_dummy8event_1234_05_06_",
-                "dummy8app_dummy8event_1234_05_07_",
-                "dummy8app_dummy8event_1234_06_01_",
-                "dummy8app_dummy8event_1235_05_06_",
-                "dummy8app_dummy8event_2345_06_09_",
-                "dummy8app_dummy8event_2345_07_09_",
+                "dummy8event_1234_05_06_",
+                "dummy8event_1234_05_07_",
+                "dummy8event_1234_06_01_",
+                "dummy8event_1235_05_06_",
+                "dummy8event_2345_06_09_",
+                "dummy8event_2345_07_09_",
             },
         )
 
@@ -482,15 +485,18 @@ class TestMonthlyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
         Monthly8Event.refresh_timeseries_indexes()
 
     def test_indexes(self):
-        _index_names = {_name for _name, _ in Monthly8Event.each_timeseries_index()}
+        _index_names = {
+            _strip_test_prefix(_name)
+            for _name, _ in Monthly8Event.each_timeseries_index()
+        }
         self.assertEqual(
             _index_names,
             {
-                "dummy8evenz_eventlog_1234_05_",
-                "dummy8evenz_eventlog_1234_06_",
-                "dummy8evenz_eventlog_1235_05_",
-                "dummy8evenz_eventlog_2345_06_",
-                "dummy8evenz_eventlog_2345_07_",
+                "eventlog_1234_05_",
+                "eventlog_1234_06_",
+                "eventlog_1235_05_",
+                "eventlog_2345_06_",
+                "eventlog_2345_07_",
             },
         )
 
@@ -540,13 +546,16 @@ class TestYearlyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
         ThingHappened.refresh_timeseries_indexes()
 
     def test_indexes(self):
-        _index_names = {_name for _name, _ in ThingHappened.each_timeseries_index()}
+        _index_names = {
+            _strip_test_prefix(_name)
+            for _name, _ in ThingHappened.each_timeseries_index()
+        }
         self.assertEqual(
             _index_names,
             {
-                "dummy8app_happen_1234_",
-                "dummy8app_happen_1235_",
-                "dummy8app_happen_2345_",
+                "happen_1234_",
+                "happen_1235_",
+                "happen_2345_",
             },
         )
 
@@ -581,3 +590,9 @@ class TestYearlyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
             ThingHappened.search_timeseries_range((1234, 5, 6, 2), (1234, 5, 7)),
             {"b"},
         )
+
+
+def _strip_test_prefix(index_name: str) -> str:
+    # strip uuid test prefix
+    (_, _, _without_prefix) = index_name.partition("_")
+    return _without_prefix

--- a/elasticsearch_metrics/tests/test_imps_elastic8.py
+++ b/elasticsearch_metrics/tests/test_imps_elastic8.py
@@ -23,7 +23,7 @@ from elasticsearch_metrics.tests._test_util import (
 )
 from elasticsearch_metrics.tests.dummy8app.metrics import (
     Dummy8Event,
-    Dummy8EventWithExplicitNamePrefix,
+    Monthly8Event,
     ThingHappened,
     ThingHappeningsReport,
 )
@@ -37,55 +37,103 @@ def _es8_client(
     return _backend.elastic8_client
 
 
-class TestFormatIndexName(SimpleDjelmeTestCase):
+class TestNamesAndPatterns(SimpleDjelmeTestCase):
     def test_format_timeseries_index_name(self):
         date = dt.date(2020, 2, 14)
         self.assertEqual(
             Dummy8Event.format_timeseries_index_name(date),
             "dummy8app_dummy8event_2020_02_14_",
         )
-
-    def test_format_timeseries_index_name__cls_timedepth(self):
-        date = dt.date(2020, 2, 14)
+        self.assertEqual(
+            Monthly8Event.format_timeseries_index_name(date),
+            "dummy8evenz_eventlog_2020_02_",
+        )
         self.assertEqual(
             ThingHappened.format_timeseries_index_name(date),
             "dummy8app_happen_2020_",
         )
         self.assertEqual(
             ThingHappeningsReport.format_timeseries_index_name(date),
-            "blarg_thinghappeningsreport_2020_02_14_",
+            "blarg_thinghappeningsreport_2020_02_",
         )
 
     def test_format_index_name_respects_date_format_setting(self):
         with self.settings(DJELME_DEFAULT_TIMEDEPTH=4):
             date = dt.date(2020, 2, 14)
+            # no timedepth set; use default setting
             self.assertEqual(
                 Dummy8Event.format_timeseries_index_name(date),
                 "dummy8app_dummy8event_2020_02_14_00_",
             )
+            # timedepth set; ignore default setting
+            self.assertEqual(
+                Monthly8Event.format_timeseries_index_name(date),
+                "dummy8evenz_eventlog_2020_02_",
+            )
             self.assertEqual(
                 ThingHappened.format_timeseries_index_name(date),
-                "dummy8app_happen_2020_",  # ThingHappened.Meta has timedepth=1
+                "dummy8app_happen_2020_",
+            )
+            self.assertEqual(
+                ThingHappeningsReport.format_timeseries_index_name(date),
+                "blarg_thinghappeningsreport_2020_02_",
             )
 
-
-class TestFormatIndexPattern(SimpleDjelmeTestCase):
-    def test_format_timeseries_index_pattern(self):
+    def test_format_timeseries_index_pattern__lotsa_parts(self):
         _timeparts = (2020, 2, 14, 0, 1, 2)
         self.assertEqual(
             Dummy8Event.format_timeseries_index_pattern(_timeparts),
             "dummy8app_dummy8event_2020_02_14_*",
         )
-
-    def test_format_timeseries_index_pattern__cls_timedepth(self):
-        _timeparts = (2020, 2, 14)
+        self.assertEqual(
+            Monthly8Event.format_timeseries_index_pattern(_timeparts),
+            "dummy8evenz_eventlog_2020_02_*",
+        )
         self.assertEqual(
             ThingHappened.format_timeseries_index_pattern(_timeparts),
             "dummy8app_happen_2020_*",
         )
         self.assertEqual(
             ThingHappeningsReport.format_timeseries_index_pattern(_timeparts),
-            "blarg_thinghappeningsreport_2020_02_14_*",
+            "blarg_thinghappeningsreport_2020_02_*",
+        )
+
+    def test_format_timeseries_index_pattern__some_parts(self):
+        _timeparts = (2020, 2, 14)
+        self.assertEqual(
+            Dummy8Event.format_timeseries_index_pattern(_timeparts),
+            "dummy8app_dummy8event_2020_02_14_*",
+        )
+        self.assertEqual(
+            Monthly8Event.format_timeseries_index_pattern(_timeparts),
+            "dummy8evenz_eventlog_2020_02_*",
+        )
+        self.assertEqual(
+            ThingHappened.format_timeseries_index_pattern(_timeparts),
+            "dummy8app_happen_2020_*",
+        )
+        self.assertEqual(
+            ThingHappeningsReport.format_timeseries_index_pattern(_timeparts),
+            "blarg_thinghappeningsreport_2020_02_*",
+        )
+
+    def test_format_timeseries_index_pattern__one_part(self):
+        _timeparts = (2020,)
+        self.assertEqual(
+            Dummy8Event.format_timeseries_index_pattern(_timeparts),
+            "dummy8app_dummy8event_2020_*",
+        )
+        self.assertEqual(
+            Monthly8Event.format_timeseries_index_pattern(_timeparts),
+            "dummy8evenz_eventlog_2020_*",
+        )
+        self.assertEqual(
+            ThingHappened.format_timeseries_index_pattern(_timeparts),
+            "dummy8app_happen_2020_*",
+        )
+        self.assertEqual(
+            ThingHappeningsReport.format_timeseries_index_pattern(_timeparts),
+            "blarg_thinghappeningsreport_2020_*",
         )
 
     def test_format_index_pattern_respects_date_format_setting(self):
@@ -96,8 +144,12 @@ class TestFormatIndexPattern(SimpleDjelmeTestCase):
                 "dummy8app_dummy8event_2020_02_14_00_*",
             )
             self.assertEqual(
+                Monthly8Event.format_timeseries_index_pattern(_timeparts),
+                "dummy8evenz_eventlog_2020_02_*",
+            )
+            self.assertEqual(
                 ThingHappened.format_timeseries_index_pattern(_timeparts),
-                "dummy8app_happen_2020_*",  # ThingHappened.Meta has timedepth=1
+                "dummy8app_happen_2020_*",
             )
 
 
@@ -138,12 +190,9 @@ class TestGetIndexTemplate(SimpleDjelmeTestCase):
         assert properties["thing_id"] == {"type": "keyword"}
         assert properties["happen_code"] == {"type": "keyword"}
 
-    # regression test
     def test_mappings_are_not_shared(self):
         template1 = Dummy8Event.get_timeseries_template().to_dict()
-        template2 = (
-            Dummy8EventWithExplicitNamePrefix.get_timeseries_template().to_dict()
-        )
+        template2 = Monthly8Event.get_timeseries_template().to_dict()
         assert "intensity" in template1["template"]["mappings"]["properties"]
         assert "intenzity" not in template1["template"]["mappings"]["properties"]
         assert "intensity" not in template2["template"]["mappings"]["properties"]
@@ -169,7 +218,7 @@ class TestGetIndexTemplate(SimpleDjelmeTestCase):
     def test_template_name_defined_with_no_template_falls_back_to_default_template(
         self,
     ):
-        template = Dummy8EventWithExplicitNamePrefix.get_timeseries_template()
+        template = Monthly8Event.get_timeseries_template()
         # prefix and recordtype specified in class Meta
         assert template._template_name == "dummy8evenz_eventlog__template"
         # template pattern generated using same options
@@ -338,7 +387,7 @@ class TestInit(RealElasticTestCase, autosetup_djelme_backends=False):
         self.assertEqual(_properties["thing_id"], {"type": "keyword"})
         self.assertEqual(_properties["happen_code"], {"type": "keyword"})
         # no indexes; only the template
-        self.assertFalse(list(ThingHappened.each_index()))
+        self.assertFalse(list(ThingHappened.each_timeseries_index()))
 
     def test_check_djelme_setup(self):
         with self.assertRaises(IndexTemplateNotFoundError):
@@ -371,10 +420,10 @@ class TestDailyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
         Dummy8Event.record(timestamp=dt.datetime(1235, 5, 6), intensity=111)
         Dummy8Event.record(timestamp=dt.datetime(2345, 6, 9), intensity=11)
         Dummy8Event.record(timestamp=dt.datetime(2345, 7, 9), intensity=13)
-        Dummy8Event.refresh_all()
+        Dummy8Event.refresh_timeseries_indexes()
 
     def test_indexes(self):
-        _index_names = {_name for _name, _ in Dummy8Event.each_index()}
+        _index_names = {_name for _name, _ in Dummy8Event.each_timeseries_index()}
         self.assertEqual(
             _index_names,
             {
@@ -413,4 +462,122 @@ class TestDailyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
         _assert_intens(
             Dummy8Event.search_timeseries_range((1234, 6), dt.date(2345, 7, 1)),
             {7, 111, 11},
+        )
+        _assert_intens(
+            Dummy8Event.search_timeseries_range((1234, 5, 6, 2), (1234, 5, 7)),
+            {2},
+        )
+
+
+class TestMonthlyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
+    def setUp(self):
+        super().setUp()
+        Monthly8Event.record(timestamp=dt.datetime(1234, 5, 6), intenzity=1)
+        Monthly8Event.record(timestamp=dt.datetime(1234, 5, 6, 7), intenzity=2)
+        Monthly8Event.record(timestamp=dt.datetime(1234, 5, 7), intenzity=3)
+        Monthly8Event.record(timestamp=dt.datetime(1234, 6, 1), intenzity=7)
+        Monthly8Event.record(timestamp=dt.datetime(1235, 5, 6), intenzity=111)
+        Monthly8Event.record(timestamp=dt.datetime(2345, 6, 9), intenzity=11)
+        Monthly8Event.record(timestamp=dt.datetime(2345, 7, 9), intenzity=13)
+        Monthly8Event.refresh_timeseries_indexes()
+
+    def test_indexes(self):
+        _index_names = {_name for _name, _ in Monthly8Event.each_timeseries_index()}
+        self.assertEqual(
+            _index_names,
+            {
+                "dummy8evenz_eventlog_1234_05_",
+                "dummy8evenz_eventlog_1234_06_",
+                "dummy8evenz_eventlog_1235_05_",
+                "dummy8evenz_eventlog_2345_06_",
+                "dummy8evenz_eventlog_2345_07_",
+            },
+        )
+
+    def test_search(self):
+        def _assert_intenz(hits, expected_intenzities):
+            _actual = {_hit.intenzity for _hit in hits}
+            self.assertEqual(_actual, expected_intenzities)
+
+        _assert_intenz(
+            Monthly8Event.search(),
+            {1, 2, 3, 7, 11, 13, 111},
+        )
+        _assert_intenz(
+            Monthly8Event.search_timeseries_range((1234,), (1235,)),
+            {1, 2, 3, 7},
+        )
+        _assert_intenz(
+            Monthly8Event.search_timeseries_range((1233,), (1234,)),
+            set(),
+        )
+        _assert_intenz(
+            Monthly8Event.search_timeseries_range(
+                dt.date(1234, 5, 6), dt.date(1234, 5, 7)
+            ),
+            {1, 2},
+        )
+        _assert_intenz(
+            Monthly8Event.search_timeseries_range((1234, 6), dt.date(2345, 7, 1)),
+            {7, 111, 11},
+        )
+        _assert_intenz(
+            Monthly8Event.search_timeseries_range((1234, 5, 6, 2), (1234, 5, 7)),
+            {2},
+        )
+
+
+class TestYearlyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
+    def setUp(self):
+        super().setUp()
+        ThingHappened.record(timestamp=dt.datetime(1234, 5, 6), thing_id="a")
+        ThingHappened.record(timestamp=dt.datetime(1234, 5, 6, 7), thing_id="b")
+        ThingHappened.record(timestamp=dt.datetime(1234, 5, 7), thing_id="c")
+        ThingHappened.record(timestamp=dt.datetime(1234, 6, 1), thing_id="d")
+        ThingHappened.record(timestamp=dt.datetime(1235, 5, 6), thing_id="e")
+        ThingHappened.record(timestamp=dt.datetime(2345, 6, 9), thing_id="f")
+        ThingHappened.record(timestamp=dt.datetime(2345, 7, 9), thing_id="g")
+        ThingHappened.refresh_timeseries_indexes()
+
+    def test_indexes(self):
+        _index_names = {_name for _name, _ in ThingHappened.each_timeseries_index()}
+        self.assertEqual(
+            _index_names,
+            {
+                "dummy8app_happen_1234_",
+                "dummy8app_happen_1235_",
+                "dummy8app_happen_2345_",
+            },
+        )
+
+    def test_search(self):
+        def _assert_things(hits, expected_thing_ids):
+            _actual = {_hit.thing_id for _hit in hits}
+            self.assertEqual(_actual, expected_thing_ids)
+
+        _assert_things(
+            ThingHappened.search(),
+            {"a", "b", "c", "d", "e", "f", "g"},
+        )
+        _assert_things(
+            ThingHappened.search_timeseries_range((1234,), (1235,)),
+            {"a", "b", "c", "d"},
+        )
+        _assert_things(
+            ThingHappened.search_timeseries_range((1233,), (1234,)),
+            set(),
+        )
+        _assert_things(
+            ThingHappened.search_timeseries_range(
+                dt.date(1234, 5, 6), dt.date(1234, 5, 7)
+            ),
+            {"a", "b"},
+        )
+        _assert_things(
+            ThingHappened.search_timeseries_range((1234, 6), dt.date(2345, 7, 1)),
+            {"d", "e", "f"},
+        )
+        _assert_things(
+            ThingHappened.search_timeseries_range((1234, 5, 6, 2), (1234, 5, 7)),
+            {"b"},
         )

--- a/elasticsearch_metrics/tests/test_imps_elastic8.py
+++ b/elasticsearch_metrics/tests/test_imps_elastic8.py
@@ -216,6 +216,7 @@ class TestRecord(MockSaveTestCase):
         p = ThingHappened.record(timestamp=timestamp, thing_id="abc12")
         assert self.mocked_es8_save.call_count == 1
         assert p.timestamp == timestamp
+        assert p.timestamp_parts == "2017.8.21.0.0.0"
         assert p.thing_id == "abc12"
 
     @unittest.mock.patch.object(timezone, "now")
@@ -272,7 +273,7 @@ class TestSignals(MockSaveTestCase):
         assert post_save_kwargs["sender"] is ThingHappened
 
 
-class TestCreateDocument(RealElasticTestCase, autosetup_djelme_backends=True):
+class TestCreateAndSearch(RealElasticTestCase, autosetup_djelme_backends=True):
     def test_create_document(self):
         _thing_id = "12345"
         _happen_code = "zyxwv"
@@ -294,6 +295,8 @@ class TestCreateDocument(RealElasticTestCase, autosetup_djelme_backends=True):
         assert properties["timestamp"] == {"type": "date"}
         assert properties["thing_id"] == {"type": "keyword"}
         assert properties["happen_code"] == {"type": "keyword"}
+
+    def test_search(self): ...  # TODO
 
 
 class TestInit(RealElasticTestCase, autosetup_djelme_backends=False):

--- a/elasticsearch_metrics/util/timeseries_naming.py
+++ b/elasticsearch_metrics/util/timeseries_naming.py
@@ -13,6 +13,7 @@ __all__ = (
     "parse_index_pattern",
     "format_namepart",
     "format_template_name",
+    "timeparts_from_date",
 )
 
 import collections
@@ -103,10 +104,8 @@ def _each_timeparts_for_timerange(
     if timedepth <= 0:
         yield (), True  # reached timedepth; wildcard
         return
-    _from_part, *_from_rest = from_timeparts
-    _until_part, *_until_rest = until_timeparts
-    assert _from_part <= _until_part
-
+    _from_part, *_from_rest = from_timeparts or [0]
+    _until_part, *_until_rest = until_timeparts or [0]
     if include_less_granular:
         yield (), False  # include less-granular non-wildcard index, if it exists
     if _from_part == _until_part:
@@ -118,7 +117,7 @@ def _each_timeparts_for_timerange(
             include_less_granular=include_less_granular,
         ):
             yield (_from_part, *_rest_parts), _is_wildcard
-    elif (_until_part - _from_part) <= max_fanout:  # not too far apart
+    elif 0 < (_until_part - _from_part) <= max_fanout:  # not too far apart
         for _parallel_part in range(_from_part, _until_part):
             yield (_parallel_part,), True  # wildcard
         if any(_until_rest):  # some of the "until" bucket is included
@@ -250,22 +249,13 @@ def format_index_pattern_for_range(
     >>> format_index_pattern_for_range('ap', 'rt',
     ...     (200, 5), datetime.date(200, 5, 8),
     ...     timedepth=3)
+    'ap_rt_200_05_*'
     """
-    _from_timeparts = (
-        timeparts_from_date(from_when, timedepth)
-        if isinstance(from_when, datetime.date)
-        else from_when
-    )
-    _until_timeparts = (
-        timeparts_from_date(until_when, timedepth)
-        if isinstance(until_when, datetime.date)
-        else until_when
-    )
     return format_index_pattern_for_timerange(
-        prefix,
-        recordtype,
-        _from_timeparts,
-        _until_timeparts,
+        prefix=prefix,
+        recordtype=recordtype,
+        from_timeparts=_whenparts(from_when, timedepth),
+        until_timeparts=_whenparts(until_when, timedepth),
         timedepth=timedepth,
         include_less_granular=include_less_granular,
         only_datelike=True,
@@ -365,7 +355,7 @@ def _parse_timename(given_timename: str) -> Iterator[int]:
         yield int(_part)
 
 
-def timename_from_datestr(given_date: str, part_count: int) -> str:
+def timename_from_datestr(given_date: str, timedepth: int) -> str:
     """
     >>> timename_from_datestr('2345-06-07', 1)
     '2345'
@@ -384,28 +374,32 @@ def timename_from_datestr(given_date: str, part_count: int) -> str:
     """
     return timename_from_date(
         datetime.datetime.fromisoformat(given_date),
-        part_count=part_count,
+        timedepth=timedepth,
     )
 
 
-def timename_from_date(given_date: datetime.date, part_count: int) -> str:
+def timename_from_date(given_date: datetime.date, timedepth: int) -> str:
     """
     >>> timename_from_date(datetime.date(3456, 7, 8), 2)
     '3456_07'
     """
-    _timeparts = itertools.islice(_each_timepart_from_date(given_date), part_count)
+    _timeparts = itertools.islice(_each_timepart_from_date(given_date), timedepth)
     return _format_timename(*_timeparts)
 
 
-def timeparts_from_date(given_date: datetime.date, part_count: int) -> tuple[int, ...]:
+def timeparts_from_date(given_date: datetime.date, timedepth: int) -> tuple[int, ...]:
     """
     >>> timeparts_from_date(datetime.date(3456, 7, 8), 2)
     (3456, 7)
     >>> timeparts_from_date(datetime.date(3456, 7, 8), 4)
     (3456, 7, 8, 0)
     """
-    _parts = itertools.chain(_each_timepart_from_date(given_date), itertools.repeat(0))
-    return tuple(itertools.islice(_parts, part_count))
+    return tuple(
+        itertools.islice(
+            _zeropadded_timeparts(_each_timepart_from_date(given_date)),
+            timedepth,
+        )
+    )
 
 
 def _each_timepart_from_date(given_date: datetime.date) -> Iterator[int]:
@@ -418,5 +412,66 @@ def _each_timepart_from_date(given_date: datetime.date) -> Iterator[int]:
         yield given_date.second
 
 
+def _zeropadded_timeparts(
+    timeparts: collections.abc.Iterable[int],
+) -> collections.abc.Iterator[int]:
+    yield from timeparts
+    yield from itertools.repeat(0)
+
+
 def _format_timepart(timepart: int) -> str:
     return f"{timepart:0{_TIMEPART_MIN_LEN}}"
+
+
+def _whenparts(
+    when: tuple[int, ...] | datetime.date,
+    timedepth: int,
+) -> tuple[int, ...]:
+    return (
+        timeparts_from_date(when, timedepth)
+        if isinstance(when, datetime.date)
+        else tuple(itertools.islice(_zeropadded_timeparts(when), timedepth))
+    )
+
+
+def full_semverlike_timeparts(when: tuple[int, ...] | datetime.date) -> str:
+    """
+    >>> full_semverlike_timeparts((3000, 2))
+    '3000.2'
+    >>> full_semverlike_timeparts(datetime.date(3000, 7, 12))
+    '3000.7.12'
+    >>> full_semverlike_timeparts(datetime.datetime(3000, 9, 1))
+    '3000.9.1.0.0.0'
+    """
+    _parts = (
+        timeparts_from_date(
+            when, timedepth=(6 if isinstance(when, datetime.datetime) else 3)
+        )
+        if isinstance(when, datetime.date)
+        else when
+    )
+    return ".".join(map(str, _parts))
+
+
+def semverlike_timeparts(when: tuple[int, ...] | datetime.date, timedepth: int) -> str:
+    """
+    >>> semverlike_timeparts((3000, 2, 7, 9), timedepth=2)
+    '3000.2'
+    >>> semverlike_timeparts((3000, 2), timedepth=1)
+    '3000'
+    >>> semverlike_timeparts((3000, 2, 7, 9), timedepth=5)
+    '3000.2.7.9.0'
+
+    >>> semverlike_timeparts(datetime.date(3000, 7, 12), timedepth=3)
+    '3000.7.12'
+    >>> semverlike_timeparts(datetime.date(3000, 7, 12), timedepth=2)
+    '3000.7'
+    >>> semverlike_timeparts(datetime.date(3000, 7, 12), timedepth=1)
+    '3000'
+
+    >>> semverlike_timeparts(datetime.datetime(3000, 9, 1, 5, 2), timedepth=6)
+    '3000.9.1.5.2.0'
+    >>> semverlike_timeparts(datetime.datetime(3000, 9, 1, 5, 2), timedepth=3)
+    '3000.9.1'
+    """
+    return full_semverlike_timeparts(_whenparts(when, timedepth))

--- a/elasticsearch_metrics/util/timeseries_naming.py
+++ b/elasticsearch_metrics/util/timeseries_naming.py
@@ -222,37 +222,50 @@ def format_index_pattern_for_timerange(
     )
 
 
-def format_index_pattern_for_daterange(
+def format_index_pattern_for_range(
     prefix: str,
     recordtype: str,
-    from_date: datetime.date,
-    until_date: datetime.date,
+    from_when: tuple[int, ...] | datetime.date,
+    until_when: tuple[int, ...] | datetime.date,
     timedepth: int,
     include_less_granular: bool = False,
 ) -> str:
     """get an index-name pattern for all indexes within a date range
-    >>> format_index_pattern_for_daterange('ap', 'rt',
+    >>> format_index_pattern_for_range('ap', 'rt',
     ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 8),
     ...     timedepth=2)
     'ap_rt_2050_05_*'
-    >>> format_index_pattern_for_daterange('ap', 'rt',
+    >>> format_index_pattern_for_range('ap', 'rt',
     ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 8),
     ...     timedepth=2, include_less_granular=True)
     'ap_rt_,ap_rt_2050_,ap_rt_2050_05_*'
-    >>> format_index_pattern_for_daterange('ap', 'rt',
-    ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 8),
+    >>> format_index_pattern_for_range('ap', 'rt',
+    ...     datetime.date(2050, 5, 5), (2050, 5, 8, 10),
     ...     timedepth=3)
     'ap_rt_2050_05_05_*,ap_rt_2050_05_06_*,ap_rt_2050_05_07_*'
-    >>> format_index_pattern_for_daterange('ap', 'rt',
-    ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 8),
+    >>> format_index_pattern_for_range('ap', 'rt',
+    ...     (2050, 5, 5, 3), datetime.date(2050, 5, 8),
     ...     timedepth=3, include_less_granular=True)
     'ap_rt_,ap_rt_2050_,ap_rt_2050_05_,ap_rt_2050_05_05_*,ap_rt_2050_05_06_*,ap_rt_2050_05_07_*'
+    >>> format_index_pattern_for_range('ap', 'rt',
+    ...     (200, 5), datetime.date(200, 5, 8),
+    ...     timedepth=3)
     """
+    _from_timeparts = (
+        timeparts_from_date(from_when, timedepth)
+        if isinstance(from_when, datetime.date)
+        else from_when
+    )
+    _until_timeparts = (
+        timeparts_from_date(until_when, timedepth)
+        if isinstance(until_when, datetime.date)
+        else until_when
+    )
     return format_index_pattern_for_timerange(
         prefix,
         recordtype,
-        timeparts_from_date(from_date, timedepth),
-        timeparts_from_date(until_date, timedepth),
+        _from_timeparts,
+        _until_timeparts,
         timedepth=timedepth,
         include_less_granular=include_less_granular,
         only_datelike=True,


### PR DESCRIPTION
- fix searching across timeseries indexes in base class `elasticsearch_metrics.imps.elastic8.DjelmeRecordtype`
  - `FooRecord.search()` now returns a `Search` that queries all indexes for the type
  - add `FooRecord.search_timeseries_range(from_when, until_when)`, which returns a `Search` filtered to the given range (either dates or a "timeparts" tuple of ints), using index-name wildcard to query (roughly) only the relevant timeseries indexes
- fix bug handling `DJELME_BACKENDS` setting
- add/improve tests, docs, annotations...