### PR TITLE
[ENG-10665] support osfmetrics migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Django app for storing time-series metrics in Elasticsearch.
 
 python importables:
 - `elasticsearch_metrics`
-- `elasticsearch_metrics.imps.elastic8`
-- `elasticsearch_metrics.imps.elastic6`
+- `elasticsearch_metrics.imps.elastic8` (an implementation with elasticsearch 8)
+- `elasticsearch_metrics.imps.elastic6` (an implementation with elasticsearch 6; deprecated)
 - ...
 
 ## Pre-requisites
@@ -58,7 +58,7 @@ class UsageRecord(EventRecord):
     item_id: int
 
     class Index:
-        using = "my-es8-backend"  # optional if only one backend
+        using = "my-es8-backend"  # backend name -- required if multiple backends use the same imp
 ```
 
 Either enable autosetup...
@@ -98,19 +98,26 @@ UsageRecord.search_timeseries_range(datetime.date(2030, 1, 1), datetime.date(203
 
 ## Timeseries indexes
 
-By default, behind the scenes, a new elasticsearch index is created for each record type for each month
-in which a record is saved (using UTC timezone). You can set a default change the per-index timespan by
-setting `Meta.timedepth` on the record type.
+By default, behind the scenes, a new elasticsearch index is created for each record type for each day
+in which a record is saved (using UTC timezone). You can change this for a record type by setting
+`Meta.timedepth`, or change the default timedepth with the setting `DJELME_DEFAULT_TIMEDEPTH` (see below).
 
-- index per day, '...YYYY_MM_DD...': `timedepth = 3`
-- index per month, '...YYYY_MM...': `timedepth = 2`
+```python
+class MyEventWithMonthlyIndexes(EventRecord):
+    class Meta:
+        timedepth = 2  # YYYY_MM
+```
+
 - index per year, '...YYYY...': `timedepth = 1`
+- index per month, '...YYYY_MM...': `timedepth = 2`
+- index per day, '...YYYY_MM_DD...': `timedepth = 3` (default)
+- index per hour, '...YYYY_MM_DD_HH...': `timedepth = 4`
 
 
 ## Index settings
 
-You can configure the index template settings by setting
-`Index.settings` on a record type.
+You can configure the index settings that will be set on the index template
+and used for each new timeseries index with `Index.settings` on a record type.
 
 ```python
 class UsageRecord(EventRecord):

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ in which a record is saved (using UTC timezone). You can change this for a recor
 ```python
 class MyEventWithMonthlyIndexes(EventRecord):
     class Meta:
-        timedepth = 2  # YYYY_MM
+        timedepth = 2  # year and month
 ```
 
-- index per year, '...YYYY...': `timedepth = 1`
-- index per month, '...YYYY_MM...': `timedepth = 2`
-- index per day, '...YYYY_MM_DD...': `timedepth = 3` (default)
-- index per hour, '...YYYY_MM_DD_HH...': `timedepth = 4`
+- index per year: `timedepth = 1`
+- index per month: `timedepth = 2`
+- index per day: `timedepth = 3` (default)
+- index per hour: `timedepth = 4`
 
 
 ## Index settings
@@ -173,27 +173,6 @@ class UsageRecord(MyBaseMetric):
         app_label = "myapp"
 ```
 
-## Optional factory_boy integration
-
-```python
-import factory
-from elasticsearch_metrics.factory import MetricFactory
-
-from ..myapp.metrics import MyMetric
-
-
-class MyMetricFactory(MetricFactory):
-    my_int = factory.Faker("pyint")
-
-    class Meta:
-        model = MyMetric
-
-
-def test_something():
-    metric = MyMetricFactory()  # index metric in ES
-    assert isinstance(metric.my_int, int)
-```
-
 ## Configuration
 
 * `DJELME_BACKENDS`: Named backends for storing or searching records from your django app
@@ -220,9 +199,9 @@ def test_something():
 * `DJELME_DEFAULT_TIMEDEPTH`: Set the granularity of timeseries indexes by the number of "time parts" in index names
     ```
     DJELME_DEFAULT_TIMEDEPTH = 1  # yearly indexes; YYYY
-    DJELME_DEFAULT_TIMEDEPTH = 2  # monthly indexes; YYYY_MM
-    DJELME_DEFAULT_TIMEDEPTH = 3  # daily indexes; YYYY_MM_DD (this is the default)
-    DJELME_DEFAULT_TIMEDEPTH = 4  # hourly indexes; YYYY_MM_DD_HH
+    DJELME_DEFAULT_TIMEDEPTH = 2  # monthly indexes; YYYY.MM
+    DJELME_DEFAULT_TIMEDEPTH = 3  # daily indexes; YYYY.MM.DD (this is the default)
+    DJELME_DEFAULT_TIMEDEPTH = 4  # hourly indexes; YYYY.MM.DD.HH
     ```
     you can also set `Meta.timedepth` on a specific record type; this will take precedence
 

--- a/elasticsearch_metrics/__init__.py
+++ b/elasticsearch_metrics/__init__.py
@@ -8,3 +8,10 @@ __all__ = (
     "management",
     "util",
 )
+
+###
+# timedepth constants, for when you'd rather think in dates than timedepths
+YEARLY = 1
+MONTHLY = 2
+DAILY = 3
+HOURLY = 4

--- a/elasticsearch_metrics/apps.py
+++ b/elasticsearch_metrics/apps.py
@@ -33,8 +33,6 @@ class ElasticsearchMetricsConfig(AppConfig):
             )
         # autosetup? (default no)
         if getattr(settings, AUTOSETUP_SETTING, False) is True:
-            for (
-                _backend_name,
-                _recordtypes,
-            ) in djelme_registry.each_recordtype_by_backend():
+            _types_by_backend = djelme_registry.recordtypes_by_backend()
+            for _backend_name, _recordtypes in _types_by_backend.items():
                 djelme_registry.get_backend(_backend_name).djelme_setup(_recordtypes)

--- a/elasticsearch_metrics/constants.py
+++ b/elasticsearch_metrics/constants.py
@@ -1,0 +1,7 @@
+###
+# timedepths, for when you'd rather think in dates
+
+YEARLY = 1
+MONTHLY = 2
+DAILY = 3
+HOURLY = 4

--- a/elasticsearch_metrics/constants.py
+++ b/elasticsearch_metrics/constants.py
@@ -1,7 +1,0 @@
-###
-# timedepths, for when you'd rather think in dates
-
-YEARLY = 1
-MONTHLY = 2
-DAILY = 3
-HOURLY = 4

--- a/elasticsearch_metrics/imps/elastic6.py
+++ b/elasticsearch_metrics/imps/elastic6.py
@@ -349,7 +349,6 @@ class DjelmeElastic6Backend:
 
     backend_name: str
     imp_kwargs: dict[str, str]
-    namespace_prefix: str = ""
 
     @property
     def elastic6_client(self):

--- a/elasticsearch_metrics/imps/elastic6.py
+++ b/elasticsearch_metrics/imps/elastic6.py
@@ -99,8 +99,8 @@ class MetricMeta(IndexMeta):
             # compute it as <app label>_<lowercased class name>
             template_name = f"{app_label}_{metric_name}"
 
-        new_cls._template_name = template_name
-        new_cls._template_pattern = f"{template_name}_*"  # template pattern
+        new_cls.__template_name = template_name
+        new_cls.__template_pattern = f"{template_name}_*"  # template pattern
         # Abstract base metrics can't be instantiated and don't appear in
         # the list of metrics for an app.
         if not abstract:
@@ -134,6 +134,16 @@ class MetricMeta(IndexMeta):
         for a in index_config.get("analyzers", ()):
             i.analyzer(a)
         return i
+
+    @property
+    def _template_name(self):
+        _prefix = self.get_timeseries_name_prefix()
+        return f"{_prefix}{self.__template_name}"
+
+    @property
+    def _template_pattern(self):
+        _prefix = self.get_timeseries_name_prefix()
+        return f"{_prefix}{self.__template_pattern}"
 
 
 # We need this intermediate BaseMetric class so that
@@ -262,10 +272,7 @@ class BaseMetric(metaclass=MetricMeta):
             settings, "ELASTICSEARCH_METRICS_DATE_FORMAT", DEFAULT_DATE_FORMAT
         )
         date_formatted = date.strftime(dateformat)
-        _name_parts = (cls._template_name, date_formatted)
-        if _prefix := cls.get_timeseries_name_prefix():
-            _name_parts = (_prefix, *_name_parts)
-        return "_".join(_name_parts)
+        return f"{cls._template_name}_{date_formatted}"
 
 
 class Metric(Document, BaseMetric):

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -12,9 +12,12 @@
 """
 
 __all__ = (
-    "TimeseriesRecord",
     "EventRecord",
+    "CountedUsageRecord",
     "CyclicRecord",
+    # for ProtoDjelmeImp:
+    "djelme_backend",
+    "djelme_when_ready",
 )
 import collections
 import dataclasses
@@ -39,7 +42,7 @@ from elasticsearch_metrics.protocols import (
     ProtoDjelmeRecord,
 )
 from elasticsearch_metrics.util import timeseries_naming
-from elasticsearch_metrics.util.timeparts import format_full_timeparts
+from elasticsearch_metrics.util.timeparts import format_full_timeparts, format_timeparts
 from elasticsearch_metrics.util.unique_together import get_unique_id
 from elasticsearch_metrics.util.anon_enough import opaque_sessionhour_id
 
@@ -220,7 +223,7 @@ class DjelmeRecordtype(esdsl.Document, metaclass=_DjelmeRecordtypeMetaclass):
         assert _unique_id or not self.UNIQUE_TOGETHER_FIELDS
         self.unique_id = _unique_id or ""
         # make it unique by setting doc id in elasticsearch
-        if _unique_id and not self.meta.id:
+        if _unique_id:
             self.meta.id = _unique_id
 
     def _get_unique_id(self) -> str | None:
@@ -238,12 +241,11 @@ class DjelmeRecordtype(esdsl.Document, metaclass=_DjelmeRecordtypeMetaclass):
 
 
 class TimeseriesRecord(DjelmeRecordtype):
-    timestamp: datetime.datetime = esdsl.mapped_field(default_factory=lambda: utcnow())
     # the 'version' field type allows range queries on semver-like strings
     # that fit perfectly with "timeparts" representation of a UTC datetime
     # as a sequence of integers -- helps to avoid time zones and date math
     # (e.g. '2000' < '2000.5.10' < '2000.5.20.20.20' < '2000.11' < '2001')
-    timeseries_timeparts: str = esdsl.mapped_field(esdsl.Version(), default="")
+    timeseries_timeparts: str = esdsl.mapped_field(esdsl.Version())
 
     class Meta:
         abstract = True
@@ -262,10 +264,16 @@ class TimeseriesRecord(DjelmeRecordtype):
         cls.sync_index_template(using=using)
 
     @classmethod
-    def search(cls, *, index=None, **kwargs):
+    def search(
+        cls,
+        using: str | Elastic8Client | None = None,
+        index: str | None = None,
+    ) -> esdsl.Search[
+        "typing.Self"
+    ]:  # typing.Self added in py 3.11 -- str annotation until 3.10 eol
         return super().search(
+            using=using,
             index=(index or cls.format_timeseries_index_pattern()),
-            **kwargs,
         )
 
     @classmethod
@@ -278,13 +286,13 @@ class TimeseriesRecord(DjelmeRecordtype):
         _index_pattern = cls.format_timeseries_index_pattern_for_range(
             from_when, until_when
         )
-        _timestamp_q = esdsl.query.Range(
+        _timeseries_q = esdsl.query.Range(
             timeseries_timeparts={
                 "gte": format_full_timeparts(from_when),
                 "lt": format_full_timeparts(until_when),
             }
         )
-        return cls.search(index=_index_pattern).filter(_timestamp_q)
+        return cls.search(index=_index_pattern).filter(_timeseries_q)
 
     @classmethod
     def refresh_timeseries_indexes(cls, using: str | None = None) -> None:
@@ -465,23 +473,24 @@ class TimeseriesRecord(DjelmeRecordtype):
     def __init__(self, *args, **kwargs):
         assert not self.__class__.is_abstract
         super().__init__(*args, **kwargs)
-        self.timeseries_timeparts = self._get_timeseries_timeparts()
+        self.timeseries_timeparts = self.get_timeseries_timeparts()
 
-    def _get_timeseries_timeparts(self) -> str:
+    def get_timeseries_timeparts(self) -> str:
         """semverlike string of timeparts, used to choose a timeseries index"""
-        return format_full_timeparts(self.timestamp)
+        raise NotImplementedError(
+            f"{self.__class__!r} must implement get_timeseries_timeparts"
+        )
 
     def djelme_index_name(self) -> str:
         """the index name for this record instance
 
         for ProtoDjelmeRecord
         """
-        _when = self._get_timeseries_timeparts()
-        assert _when is not None
+        assert self.timeseries_timeparts
         _index_name = timeseries_naming.format_index_name(
             app_label=self.__class__.app_label,
             recordtype=self.get_timeseries_recordtype_name(),
-            timeparts=_when,
+            timeparts=self.timeseries_timeparts,
             max_timedepth=self.get_timedepth(),
         )
         return "".join((self.get_timeseries_name_prefix(), _index_name))
@@ -508,9 +517,17 @@ class TimeseriesRecord(DjelmeRecordtype):
 # TODO: EventRecord expiration
 # class EventRecord(TimeseriesRecord, ProtoExpirableRecord?):
 class EventRecord(TimeseriesRecord):
+    timestamp: datetime.datetime = esdsl.mapped_field(default_factory=lambda: utcnow())
 
     class Meta:
         abstract = True
+
+    def get_timeseries_timeparts(self) -> str:
+        """semverlike string of timeparts, used to choose a timeseries index
+
+        for TimeseriesRecord
+        """
+        return format_full_timeparts(self.timestamp)
 
 
 # class CountedUsageRecord(EventRecord, ProtoCountedUsage):
@@ -571,9 +588,14 @@ class CountedUsageRecord(EventRecord):
 class CyclicRecord(TimeseriesRecord):
     """CyclicRecord: for recording something on a regular cycle"""
 
-    CYCLE_TIMEDEPTH: typing.ClassVar[int]
+    UNIQUE_TOGETHER_FIELDS: typing.ClassVar[collections.abc.Iterable[str]] = (
+        "cycle_coverage",
+    )
 
-    cycle_timeparts: str = esdsl.mapped_field(esdsl.Version(), default="")
+    CYCLE_TIMEDEPTH: typing.ClassVar[int]  # required on subclasses
+
+    cycle_coverage: str = esdsl.mapped_field(esdsl.Version())
+    created: datetime.datetime = esdsl.mapped_field(default_factory=lambda: utcnow())
 
     class Meta:
         abstract = True
@@ -586,13 +608,19 @@ class CyclicRecord(TimeseriesRecord):
                 raise ImproperlyConfigured(
                     f"expected CYCLE_TIMEDEPTH integer on {cls.__module__}.{cls.__qualname__}"
                 )
+            if "cycle_coverage" not in cls.UNIQUE_TOGETHER_FIELDS:
+                raise ImproperlyConfigured(
+                    f'CyclicRecord subclasses must have "cycle_coverage" in UNIQUE_TOGETHER_FIELDS ({cls!r})'
+                )
 
-    def _get_timeseries_timeparts(self) -> str:
-        """the datetime used to choose a timeseries index
+    def get_timeseries_timeparts(self) -> str:
+        """semverlike string of timeparts, used to choose a timeseries index
 
-        overrides TimeseriesRecord to index by the start of the covered timespan
+        for TimeseriesRecord
+
+        use `cycle_coverage`; index by the start of the covered timespan
         """
-        return self.cycle_timeparts
+        return format_timeparts(self.cycle_coverage, self.CYCLE_TIMEDEPTH)
 
 
 @dataclasses.dataclass

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -366,13 +366,13 @@ class TimeseriesRecord(DjelmeRecordtype):
     def format_timeseries_index_pattern_for_range(
         cls,
         from_when: tuple[int, ...] | datetime.date,
-        until_when: tuple[int, ...] | datetime.date,
+        until_when: tuple[int, ...] | datetime.date | None,
     ) -> str:
         _pattern = timeseries_naming.format_index_pattern_for_range(
             cls.app_label,
             cls.get_timeseries_recordtype_name(),
             from_when,
-            until_when,
+            until_when or utcnow(),
             timedepth=cls.get_timedepth(),
         )
         return "".join((cls.get_timeseries_name_prefix(), _pattern))

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -23,6 +23,7 @@ import logging
 import typing
 
 import django
+from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 from elasticsearch8.exceptions import NotFoundError
 from elasticsearch8 import Elasticsearch as Elastic8Client
@@ -38,6 +39,7 @@ from elasticsearch_metrics.protocols import (
     ProtoDjelmeRecord,
 )
 from elasticsearch_metrics.util import timeseries_naming
+from elasticsearch_metrics.util.timeparts import format_full_timeparts
 from elasticsearch_metrics.util.unique_together import get_unique_id
 from elasticsearch_metrics.util.anon_enough import opaque_sessionhour_id
 
@@ -46,6 +48,10 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEDEPTH_SETTING = "DJELME_DEFAULT_TIMEDEPTH"
 _DEFAULT_TIMEDEPTH = 3  # xxxx_xx_xx_ (daily)
+
+
+def utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
 ###
@@ -232,14 +238,12 @@ class DjelmeRecordtype(esdsl.Document, metaclass=_DjelmeRecordtypeMetaclass):
 
 
 class TimeseriesRecord(DjelmeRecordtype):
-    timestamp: datetime.datetime = esdsl.mapped_field(
-        default_factory=lambda: django.utils.timezone.now()
-    )
+    timestamp: datetime.datetime = esdsl.mapped_field(default_factory=lambda: utcnow())
     # the 'version' field type allows range queries on semver-like strings
     # that fit perfectly with "timeparts" representation of a UTC datetime
     # as a sequence of integers -- helps to avoid time zones and date math
     # (e.g. '2000' < '2000.5.10' < '2000.5.20.20.20' < '2000.11' < '2001')
-    timestamp_parts: str = esdsl.mapped_field(esdsl.Version(), default="")
+    timeseries_timeparts: str = esdsl.mapped_field(esdsl.Version(), default="")
 
     class Meta:
         abstract = True
@@ -268,16 +272,16 @@ class TimeseriesRecord(DjelmeRecordtype):
     def search_timeseries_range(
         cls,
         from_when: tuple[int, ...] | datetime.date,
-        until_when: tuple[int, ...] | datetime.date,
+        until_when: tuple[int, ...] | datetime.date | None,
         **kwargs: typing.Any,
     ) -> typing.Any:
         _index_pattern = cls.format_timeseries_index_pattern_for_range(
             from_when, until_when
         )
         _timestamp_q = esdsl.query.Range(
-            timestamp_parts={
-                "gte": timeseries_naming.full_semverlike_timeparts(from_when),
-                "lt": timeseries_naming.full_semverlike_timeparts(until_when),
+            timeseries_timeparts={
+                "gte": format_full_timeparts(from_when),
+                "lt": format_full_timeparts(until_when),
             }
         )
         return cls.search(index=_index_pattern).filter(_timestamp_q)
@@ -313,18 +317,6 @@ class TimeseriesRecord(DjelmeRecordtype):
             pass
 
     @classmethod
-    def format_timeseries_index_name(
-        cls, timestamp: datetime.date | None = None
-    ) -> str:
-        _index_name = timeseries_naming.format_index_name_for_date(
-            timestamp or django.utils.timezone.now(),
-            app_label=cls.app_label,
-            recordtype=cls.get_timeseries_recordtype_name(),
-            timedepth=cls.get_timedepth(),
-        )
-        return "".join((cls.get_timeseries_name_prefix(), _index_name))
-
-    @classmethod
     def get_timeseries_template(cls) -> esdsl.ComposableIndexTemplate:
         return cls._index.as_composable_template(
             template_name=cls.get_timeseries_template_name(),
@@ -336,7 +328,7 @@ class TimeseriesRecord(DjelmeRecordtype):
         _template_name = timeseries_naming.format_template_name(
             cls.app_label, cls.get_timeseries_recordtype_name()
         )
-        return "".join(cls.get_timeseries_name_prefix(), _template_name)
+        return "".join((cls.get_timeseries_name_prefix(), _template_name))
 
     @classmethod
     def get_timeseries_recordtype_name(cls) -> str:
@@ -397,6 +389,7 @@ class TimeseriesRecord(DjelmeRecordtype):
     @classmethod
     def sync_index_template(cls, using=None):  # -> ComposableIndexTemplate:
         """Sync the index template for this metric in Elasticsearch."""
+        assert not cls.is_abstract
         _template = cls.get_timeseries_template()
         signals.pre_index_template_create.send(
             cls, index_template=_template, using=using
@@ -470,21 +463,28 @@ class TimeseriesRecord(DjelmeRecordtype):
     # instance methods
 
     def __init__(self, *args, **kwargs):
+        assert not self.__class__.is_abstract
         super().__init__(*args, **kwargs)
-        self.timestamp_parts = self._build_timestamp_parts()
+        self.timeseries_timeparts = self._get_timeseries_timeparts()
 
-    @property
-    def _timeseries_timestamp(self) -> datetime.datetime:
-        """the datetime used to choose a timeseries index"""
-        return self.timestamp
-
-    def _build_timestamp_parts(self) -> str:
-        return timeseries_naming.full_semverlike_timeparts(self._timeseries_timestamp)
+    def _get_timeseries_timeparts(self) -> str:
+        """semverlike string of timeparts, used to choose a timeseries index"""
+        return format_full_timeparts(self.timestamp)
 
     def djelme_index_name(self) -> str:
-        _when = self._timeseries_timestamp
+        """the index name for this record instance
+
+        for ProtoDjelmeRecord
+        """
+        _when = self._get_timeseries_timeparts()
         assert _when is not None
-        return self.format_timeseries_index_name(_when)
+        _index_name = timeseries_naming.format_index_name(
+            app_label=self.__class__.app_label,
+            recordtype=self.get_timeseries_recordtype_name(),
+            timeparts=_when,
+            max_timedepth=self.get_timedepth(),
+        )
+        return "".join((self.get_timeseries_name_prefix(), _index_name))
 
     def save(
         self,
@@ -495,9 +495,9 @@ class TimeseriesRecord(DjelmeRecordtype):
         return_doc_meta: bool = False,
         **kwargs: typing.Any,
     ) -> typing.Any:
-        """save the record
+        """save the record to a timeseries index
 
-        overrides `save` to choose a timeseries index based on `self._timeseries_timestamp`
+        overrides `Document.save` to choose a specific timeseries index
         """
         if index is None:
             index = self.djelme_index_name()
@@ -569,24 +569,30 @@ class CountedUsageRecord(EventRecord):
 
 
 class CyclicRecord(TimeseriesRecord):
-    """CyclicRecord: for recording a measurement on a periodic basis"""
+    """CyclicRecord: for recording something on a regular cycle"""
 
-    covers_from: datetime.datetime  # type: ignore[misc]
-    covers_before: datetime.datetime  # type: ignore[misc]
+    CYCLE_TIMEDEPTH: typing.ClassVar[int]
+
+    cycle_timeparts: str = esdsl.mapped_field(esdsl.Version(), default="")
 
     class Meta:
         abstract = True
 
-    def __init_subclass__(cls, *, cycle_timedepth: int, **kwargs) -> None:
+    def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
+        if not cls.is_abstract:
+            _cycle_timedepth = getattr(cls, "CYCLE_TIMEDEPTH", None)
+            if not isinstance(_cycle_timedepth, int):
+                raise ImproperlyConfigured(
+                    f"expected CYCLE_TIMEDEPTH integer on {cls.__module__}.{cls.__qualname__}"
+                )
 
-    @property
-    def _timeseries_timestamp(self) -> datetime.datetime:
+    def _get_timeseries_timeparts(self) -> str:
         """the datetime used to choose a timeseries index
 
         overrides TimeseriesRecord to index by the start of the covered timespan
         """
-        return self.covers_from
+        return self.cycle_timeparts
 
 
 @dataclasses.dataclass
@@ -595,7 +601,6 @@ class DjelmeElastic8Backend:
 
     backend_name: str
     imp_kwargs: dict[str, str]  # pass-thru to elasticsearch connection kwargs
-    namespace_prefix: str = ""
 
     def djelme_backend_name(self) -> str:  # for ProtoDjelmeBackend
         return self.backend_name

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -314,12 +314,13 @@ class TimeseriesRecord(DjelmeRecordtype):
     def format_timeseries_index_name(
         cls, timestamp: datetime.date | None = None
     ) -> str:
-        return timeseries_naming.format_index_name_for_date(
+        _index_name = timeseries_naming.format_index_name_for_date(
             timestamp or django.utils.timezone.now(),
-            prefix=cls.get_timeseries_name_prefix(),
+            app_label=cls.app_label,
             recordtype=cls.get_timeseries_recordtype_name(),
             timedepth=cls.get_timedepth(),
         )
+        return "".join((cls.get_timeseries_name_prefix(), _index_name))
 
     @classmethod
     def get_timeseries_template(cls) -> esdsl.ComposableIndexTemplate:
@@ -330,9 +331,10 @@ class TimeseriesRecord(DjelmeRecordtype):
 
     @classmethod
     def get_timeseries_template_name(cls) -> str:
-        return timeseries_naming.format_template_name(
-            cls.get_timeseries_name_prefix(), cls.get_timeseries_recordtype_name()
+        _template_name = timeseries_naming.format_template_name(
+            cls.app_label, cls.get_timeseries_recordtype_name()
         )
+        return "".join(cls.get_timeseries_name_prefix(), _template_name)
 
     @classmethod
     def get_timeseries_recordtype_name(cls) -> str:
@@ -344,18 +346,19 @@ class TimeseriesRecord(DjelmeRecordtype):
 
     @classmethod
     def get_timeseries_name_prefix(cls) -> str:
-        _name_prefix = cls._get_meta_attr("timeseries_name_prefix") or cls.app_label
+        _name_prefix = cls._get_meta_attr("timeseries_name_prefix") or ""
         assert isinstance(_name_prefix, str)
         return _name_prefix
 
     @classmethod
     def format_timeseries_index_pattern(cls, timeparts: tuple[int, ...] = ()) -> str:
-        return timeseries_naming.format_index_pattern(
-            prefix=cls.get_timeseries_name_prefix(),
+        _pattern = timeseries_naming.format_index_pattern(
+            app_label=cls.app_label,
             recordtype=cls.get_timeseries_recordtype_name(),
             timeparts=timeparts,
             max_timedepth=cls.get_timedepth(),
         )
+        return "".join((cls.get_timeseries_name_prefix(), _pattern))
 
     @classmethod
     def format_timeseries_index_pattern_for_range(
@@ -363,13 +366,14 @@ class TimeseriesRecord(DjelmeRecordtype):
         from_when: tuple[int, ...] | datetime.date,
         until_when: tuple[int, ...] | datetime.date,
     ) -> str:
-        return timeseries_naming.format_index_pattern_for_range(
-            cls.get_timeseries_name_prefix(),
+        _pattern = timeseries_naming.format_index_pattern_for_range(
+            cls.app_label,
             cls.get_timeseries_recordtype_name(),
             from_when,
             until_when,
             timedepth=cls.get_timedepth(),
         )
+        return "".join((cls.get_timeseries_name_prefix(), _pattern))
 
     @classmethod
     def get_timedepth(cls) -> int:
@@ -467,12 +471,18 @@ class TimeseriesRecord(DjelmeRecordtype):
         super().__init__(*args, **kwargs)
         self.timestamp_parts = self._build_timestamp_parts()
 
+    @property
+    def _timeseries_timestamp(self) -> datetime.datetime:
+        """the datetime used to choose a timeseries index"""
+        return self.timestamp
+
     def _build_timestamp_parts(self) -> str:
-        return timeseries_naming.full_semverlike_timeparts(self.timestamp)
+        return timeseries_naming.full_semverlike_timeparts(self._timeseries_timestamp)
 
     def djelme_index_name(self) -> str:
-        assert self.timestamp is not None
-        return self.format_timeseries_index_name(self.timestamp)
+        _when = self._timeseries_timestamp
+        assert _when is not None
+        return self.format_timeseries_index_name(_when)
 
     def save(
         self,
@@ -485,9 +495,8 @@ class TimeseriesRecord(DjelmeRecordtype):
     ) -> typing.Any:
         """save the record
 
-        overrides `save` to choose a timeseries index based on `self.timestamp`
+        overrides `save` to choose a timeseries index based on `self._timeseries_timestamp`
         """
-        assert self.timestamp is not None
         if index is None:
             index = self.djelme_index_name()
         ret = super().save(using=using, index=index, **kwargs)
@@ -565,6 +574,17 @@ class CyclicRecord(TimeseriesRecord):
 
     class Meta:
         abstract = True
+
+    def __init_subclass__(cls, *, cycle_timedepth: int, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+
+    @property
+    def _timeseries_timestamp(self) -> datetime.datetime:
+        """the datetime used to choose a timeseries index
+
+        overrides TimeseriesRecord to index by the start of the covered timespan
+        """
+        return self.covers_from
 
 
 @dataclasses.dataclass

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -110,8 +110,10 @@ class _DjelmeRecordtypeMetaclass(IndexMeta):
         return bool(self._get_meta_attr("abstract", False))
 
     @property
-    def app_label(self) -> str | None:
-        return djelme_registry.get_recordtype_app_label(self)
+    def app_label(self) -> str:
+        _app_label = djelme_registry.get_recordtype_app_label(self)
+        assert _app_label
+        return _app_label
 
 
 class DjelmeRecordtype(esdsl.Document, metaclass=_DjelmeRecordtypeMetaclass):

--- a/elasticsearch_metrics/management/commands/djelme_backend_check.py
+++ b/elasticsearch_metrics/management/commands/djelme_backend_check.py
@@ -1,6 +1,6 @@
 import sys
 import logging
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from django.utils.termcolors import colorize
 
@@ -19,19 +19,16 @@ class Command(BaseCommand):
         # Avoid elasticsearch requests from getting logged
         logging.getLogger("elasticsearch").setLevel(logging.CRITICAL)
         style = color_style()
-        if options["app_label"]:
-            if options["app_label"] not in djelme_registry.all_recordtypes:
-                raise CommandError(
-                    "No recordtypes found for app '{}'".format(options["app_label"])
-                )
-            app_labels = [options["app_label"]]
-        else:
-            app_labels = list(djelme_registry.each_app_label())
+        _app_labels = (
+            [options["app_label"]]
+            if options["app_label"]
+            else list(djelme_registry.each_app_label())
+        )
 
         out_of_sync_count = 0
         self.stdout.write("Checking for outdated index templates...")
-        for app_label in app_labels:
-            for _recordtype in djelme_registry.each_recordtype(app_label=app_label):
+        for _app_label in _app_labels:
+            for _recordtype in djelme_registry.each_recordtype(app_label=_app_label):
                 try:
                     _recordtype.check_djelme_setup()
                 except (

--- a/elasticsearch_metrics/management/commands/djelme_backend_setup.py
+++ b/elasticsearch_metrics/management/commands/djelme_backend_setup.py
@@ -18,27 +18,27 @@ class Command(BaseCommand):
         style = color_style()
         _given_app_label: str | None = options["app_label"]
         _app_labels: list[str]
-        if _given_app_label:
-            if _given_app_label not in djelme_registry.all_recordtypes:
-                raise CommandError(f"No recordtypes found for app {_given_app_label!r}")
-            _app_labels = [_given_app_label]
-        else:
-            _app_labels = list(djelme_registry.all_recordtypes.keys())
+        _app_labels = (
+            [_given_app_label]
+            if _given_app_label
+            else list(djelme_registry.each_app_label())
+        )
         for _app_label in _app_labels:
             self.stdout.write(
                 "Syncing recordtypes for app: '{}'".format(_app_label),
                 style.MIGRATE_HEADING,
             )
-            for (
-                _backend_name,
-                _each_recordtype,
-            ) in djelme_registry.each_recordtype_by_backend(_app_label):
-                _backend = djelme_registry.get_backend(_backend_name)
-                self.stdout.write(
-                    f"  Using backend {_backend.djelme_backend_name()!r}..."
+            try:
+                _types_by_backend = djelme_registry.recordtypes_by_backend(
+                    app_label=_app_label
                 )
-                for _recordtype in _each_recordtype:
-                    self.stdout.write(f"  Setting up {_recordtype!r}...")
+            except LookupError as _err:
+                raise CommandError(
+                    f"No recordtypes found for app {options["app_label"]!r}"
+                ) from _err
+            for _backend_name, _each_recordtype in _types_by_backend.items():
+                _backend = djelme_registry.get_backend(_backend_name)
+                self.stdout.write(f"  Using backend {_backend_name!r}...")
                 _backend.djelme_setup(_each_recordtype)
 
         self.stdout.write("Synchronized recordtypes.", style.SUCCESS)

--- a/elasticsearch_metrics/management/commands/djelme_backend_setup.py
+++ b/elasticsearch_metrics/management/commands/djelme_backend_setup.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
                 )
             except LookupError as _err:
                 raise CommandError(
-                    f"No recordtypes found for app {options["app_label"]!r}"
+                    f"No recordtypes found for app {_app_label!r}"
                 ) from _err
             for _backend_name, _each_recordtype in _types_by_backend.items():
                 _backend = djelme_registry.get_backend(_backend_name)

--- a/elasticsearch_metrics/protocols.py
+++ b/elasticsearch_metrics/protocols.py
@@ -17,7 +17,6 @@ class ProtoDjelmeImp(typing.Protocol):
     def djelme_backend(
         backend_name: str,
         imp_kwargs: dict[str, str],
-        namespace_prefix: str = "",
     ) -> ProtoDjelmeBackend:
         """djelme_backend: impstantiate a djelme backend"""
 

--- a/elasticsearch_metrics/registry.py
+++ b/elasticsearch_metrics/registry.py
@@ -2,6 +2,7 @@ import collections
 import dataclasses
 import functools
 import importlib
+import typing
 import weakref
 
 from django.apps import apps
@@ -14,6 +15,7 @@ from elasticsearch_metrics.protocols import (
     ProtoDjelmeImp,
 )
 from elasticsearch_metrics.util.django import find_app_label_for_type
+from elasticsearch_metrics.util.timeseries_naming import format_namepart
 
 __all__ = ("djelme_registry",)
 
@@ -35,7 +37,7 @@ class _DjelmeRegistry:
 
     # nested mapping from app labels => record-type names => record classes
     # (using weakref so if the class is destroyed, no longer registered)
-    all_recordtypes: collections.abc.MutableMapping[
+    _all_recordtypes: collections.abc.MutableMapping[
         str, collections.abc.MutableMapping[str, type[ProtoDjelmeRecord]]
     ] = dataclasses.field(
         default_factory=lambda: collections.defaultdict(
@@ -72,8 +74,8 @@ class _DjelmeRegistry:
     ) -> None:
         """Add a record type to the registry."""
         _app_label = app_label or find_app_label_for_type(recordtype)
-        app_recordtypes = self.all_recordtypes[_app_label]
-        recordtype_name = recordtype.__name__.lower()
+        app_recordtypes = self._all_recordtypes[_app_label]
+        recordtype_name = format_namepart(recordtype.__name__)
         if recordtype_name in app_recordtypes:
             # Raise an error for conflicting recordtype names (same behavior as apps.register_model)
             raise RuntimeError(
@@ -112,7 +114,7 @@ class _DjelmeRegistry:
 
         app_recordtypes = self._get_recordtypes_for_app(app_label)
         try:
-            return app_recordtypes[recordtype_name.lower()]
+            return app_recordtypes[format_namepart(recordtype_name)]
         except KeyError as e:
             raise LookupError(
                 "App '{}' doesn't have a '{}' metric.".format(
@@ -123,16 +125,14 @@ class _DjelmeRegistry:
     def get_recordtype_app_label(self, recordtype: type) -> str | None:
         _each_matching_app_label = (
             _app_label
-            for _app_label, _types in self.all_recordtypes.items()
-            if _types.get(recordtype.__name__.lower()) is recordtype
+            for _app_label, _types in self._all_recordtypes.items()
+            if _types.get(format_namepart(recordtype.__name__)) is recordtype
         )
         return next(_each_matching_app_label, None)
 
-    def get_backend(
-        self, backend_name: str, namespace_prefix: str = ""
-    ) -> ProtoDjelmeBackend:
+    def get_backend(self, backend_name: str) -> ProtoDjelmeBackend:
         _imp_module, _imp_kwargs = self._lookup_imp_module(backend_name)
-        return _imp_module.djelme_backend(backend_name, _imp_kwargs, namespace_prefix)
+        return _imp_module.djelme_backend(backend_name, _imp_kwargs)
 
     def get_imp_module(
         self, imp_module_name: str = "", *, backend_name: str = ""
@@ -181,12 +181,14 @@ class _DjelmeRegistry:
     ) -> collections.abc.Iterator[type[ProtoDjelmeRecord]]:
         """Iterate registered metric classes, optionally filtered on an app_label"""
         apps.check_apps_ready()  # ensure django setup done
-        _app_labels = [app_label] if app_label else self.all_recordtypes.keys()
+        _app_labels = [app_label] if app_label else self._all_recordtypes.keys()
         for _app_label in _app_labels:
             for _recordtype in self._get_recordtypes_for_app(_app_label).values():
                 yield _recordtype
 
-    def each_backend_settings(self) -> collections.abc.Iterator[tuple[str, str, dict]]:
+    def each_backend_settings(
+        self,
+    ) -> collections.abc.Iterator[tuple[str, str, dict[str, typing.Any]]]:
         for _backend_name, _imp_config in self.all_backends.items():
             if _imp_config:
                 _imp_module_name, _imp_kwargs = next(iter(_imp_config.items()))
@@ -210,23 +212,21 @@ class _DjelmeRegistry:
             yield self.get_backend(_backend_name)
 
     def each_app_label(self) -> collections.abc.Iterable[str]:
-        yield from self.all_recordtypes.keys()
+        yield from self._all_recordtypes.keys()
 
-    def each_recordtype_by_backend(
+    def recordtypes_by_backend(
         self, app_label: str = ""
-    ) -> collections.abc.Iterator[
-        tuple[str, collections.abc.Iterable[type[ProtoDjelmeRecord]]]
-    ]:
+    ) -> dict[str, collections.abc.Iterable[type[ProtoDjelmeRecord]]]:
         apps.check_apps_ready()  # ensure django setup done
         _by_backend_name: dict[str, list[type[ProtoDjelmeRecord]]] = (
             collections.defaultdict(list)
         )
-        _app_labels = [app_label] if app_label else self.all_recordtypes.keys()
+        _app_labels = [app_label] if app_label else self._all_recordtypes.keys()
         for _app_label in _app_labels:
-            for _recordtype in self.all_recordtypes[_app_label].values():
+            for _recordtype in self._get_recordtypes_for_app(_app_label).values():
                 _backend_name = self.get_backend_name_for_recordtype(_recordtype)
                 _by_backend_name[_backend_name].append(_recordtype)
-        yield from _by_backend_name.items()
+        return dict(_by_backend_name.items())
 
     ###
     # private methods
@@ -249,11 +249,11 @@ class _DjelmeRegistry:
     def _get_recordtypes_for_app(
         self, app_label: str
     ) -> collections.abc.Mapping[str, type]:
-        if app_label not in self.all_recordtypes:
+        if app_label not in self._all_recordtypes:
             raise LookupError(
                 "No recordtypes found in app with label '{}'.".format(app_label)
             )
-        return self.all_recordtypes[app_label]
+        return self._all_recordtypes[app_label]
 
 
 def _import_imp_module(imp_module_name: str) -> ProtoDjelmeImp:

--- a/elasticsearch_metrics/tests/_test_util.py
+++ b/elasticsearch_metrics/tests/_test_util.py
@@ -53,7 +53,7 @@ class RealElasticTestCase(SimpleDjelmeTestCase):
 
     def setUp(self):
         super().setUp()
-        _name_prefix = uuid.uuid4().hex
+        _name_prefix = f'{uuid.uuid4().hex}_'
         self.enterContext(
             mock.patch(
                 "elasticsearch_metrics.imps.elastic8.TimeseriesRecord.get_timeseries_name_prefix",

--- a/elasticsearch_metrics/tests/_test_util.py
+++ b/elasticsearch_metrics/tests/_test_util.py
@@ -53,7 +53,7 @@ class RealElasticTestCase(SimpleDjelmeTestCase):
 
     def setUp(self):
         super().setUp()
-        _name_prefix = f'{uuid.uuid4().hex}_'
+        _name_prefix = f"{uuid.uuid4().hex}_"
         self.enterContext(
             mock.patch(
                 "elasticsearch_metrics.imps.elastic8.TimeseriesRecord.get_timeseries_name_prefix",
@@ -76,11 +76,14 @@ class RealElasticTestCase(SimpleDjelmeTestCase):
 
     def setup_backends(self):
         # backends based on settings in django.conf.settings.DJELME_BACKENDS
-        for _backend_name, _recordtypes in djelme_registry.each_recordtype_by_backend():
+        _types_by_backend = djelme_registry.recordtypes_by_backend()
+        for _backend_name, _recordtypes in _types_by_backend.items():
             djelme_registry.get_backend(_backend_name).djelme_setup(_recordtypes)
 
     def teardown_backends(self):
-        for _backend_name, _recordtypes in djelme_registry.each_recordtype_by_backend():
+        # backends based on settings in django.conf.settings.DJELME_BACKENDS
+        _types_by_backend = djelme_registry.recordtypes_by_backend()
+        for _backend_name, _recordtypes in _types_by_backend.items():
             djelme_registry.get_backend(_backend_name).djelme_teardown(_recordtypes)
 
 

--- a/elasticsearch_metrics/tests/dummy8app/metrics.py
+++ b/elasticsearch_metrics/tests/dummy8app/metrics.py
@@ -43,6 +43,8 @@ class ThingHappened(djelme.EventRecord):
 
 # TODO: tests using ThingHappeningsReport
 class ThingHappeningsReport(djelme.CyclicRecord):
+    CYCLE_TIMEDEPTH = 2
+
     thing_id: str
     happen_count: int
 
@@ -50,5 +52,5 @@ class ThingHappeningsReport(djelme.CyclicRecord):
         using = "my_elastic8_reports"
 
     class Meta:
-        timeseries_name_prefix = "blarg"
+        timeseries_name_prefix = "blarg_"
         timedepth = 2  # monthly timeseries indexes

--- a/elasticsearch_metrics/tests/test_doctests.py
+++ b/elasticsearch_metrics/tests/test_doctests.py
@@ -5,6 +5,7 @@ _MODULES_WITH_DOCTESTS = (
     "elasticsearch_metrics.imps.elastic8",
     "elasticsearch_metrics.util.anon_enough",
     "elasticsearch_metrics.util.timeseries_naming",
+    "elasticsearch_metrics.util.timeparts",
 )
 
 

--- a/elasticsearch_metrics/tests/test_imps_elastic8.py
+++ b/elasticsearch_metrics/tests/test_imps_elastic8.py
@@ -55,7 +55,7 @@ class TestNamesAndPatterns(SimpleDjelmeTestCase):
         )
         _thingreport = ThingHappeningsReport(
             timestamp=_stamp,
-            cycle_timeparts="1999.3.15",
+            cycle_coverage="1999.3.15",
             thing_id="wo",
             happen_count=2,
         )
@@ -86,7 +86,7 @@ class TestNamesAndPatterns(SimpleDjelmeTestCase):
             )
             _thingreport = ThingHappeningsReport(
                 timestamp=_stamp,
-                cycle_timeparts="1999.3.16",
+                cycle_coverage="1999.3.16",
                 thing_id="wha",
                 happen_count=0,
             )

--- a/elasticsearch_metrics/tests/test_imps_elastic8.py
+++ b/elasticsearch_metrics/tests/test_imps_elastic8.py
@@ -1,8 +1,6 @@
 import unittest
 import datetime as dt
 
-from django.utils import timezone
-
 import elasticsearch8
 from elasticsearch8.dsl import (
     ComposableIndexTemplate,
@@ -38,102 +36,120 @@ def _es8_client(
 
 
 class TestNamesAndPatterns(SimpleDjelmeTestCase):
-    def test_format_timeseries_index_name(self):
-        date = dt.date(2020, 2, 14)
+    def test_index_name(self):
+        _stamp = dt.datetime(2020, 2, 14)
+        _dum8event = Dummy8Event(timestamp=_stamp, intensity=7)
         self.assertEqual(
-            Dummy8Event.format_timeseries_index_name(date),
-            "dummy8app_dummy8event_2020_02_14_",
+            _dum8event.djelme_index_name(),
+            "dummy8app_dummy8event_2020.2.14.",
+        )
+        _month8event = Monthly8Event(timestamp=_stamp, intenzity=8)
+        self.assertEqual(
+            _month8event.djelme_index_name(),
+            "dummy8evenzdummy8app_eventlog_2020.2.",
+        )
+        _thingevent = ThingHappened(timestamp=_stamp, thing_id="hi")
+        self.assertEqual(
+            _thingevent.djelme_index_name(),
+            "dummy8app_happen_2020.",
+        )
+        _thingreport = ThingHappeningsReport(
+            timestamp=_stamp,
+            cycle_timeparts="1999.3.15",
+            thing_id="wo",
+            happen_count=2,
         )
         self.assertEqual(
-            Monthly8Event.format_timeseries_index_name(date),
-            "dummy8evenz_eventlog_2020_02_",
-        )
-        self.assertEqual(
-            ThingHappened.format_timeseries_index_name(date),
-            "dummy8app_happen_2020_",
-        )
-        self.assertEqual(
-            ThingHappeningsReport.format_timeseries_index_name(date),
-            "blarg_thinghappeningsreport_2020_02_",
+            _thingreport.djelme_index_name(),
+            "blarg_dummy8app_thinghappeningsreport_1999.3.",
         )
 
     def test_format_index_name_respects_date_format_setting(self):
+        _stamp = dt.datetime(2020, 2, 14)
         with self.settings(DJELME_DEFAULT_TIMEDEPTH=4):
-            date = dt.date(2020, 2, 14)
             # no timedepth set; use default setting
+            _dum8event = Dummy8Event(timestamp=_stamp, intensity=2)
             self.assertEqual(
-                Dummy8Event.format_timeseries_index_name(date),
-                "dummy8app_dummy8event_2020_02_14_00_",
+                _dum8event.djelme_index_name(),
+                "dummy8app_dummy8event_2020.2.14.0.",
             )
             # timedepth set; ignore default setting
+            _month8event = Monthly8Event(timestamp=_stamp, intenzity=2)
             self.assertEqual(
-                Monthly8Event.format_timeseries_index_name(date),
-                "dummy8evenz_eventlog_2020_02_",
+                _month8event.djelme_index_name(),
+                "dummy8evenzdummy8app_eventlog_2020.2.",
+            )
+            _thingevent = ThingHappened(timestamp=_stamp, thing_id="ha")
+            self.assertEqual(
+                _thingevent.djelme_index_name(),
+                "dummy8app_happen_2020.",
+            )
+            _thingreport = ThingHappeningsReport(
+                timestamp=_stamp,
+                cycle_timeparts="1999.3.16",
+                thing_id="wha",
+                happen_count=0,
             )
             self.assertEqual(
-                ThingHappened.format_timeseries_index_name(date),
-                "dummy8app_happen_2020_",
-            )
-            self.assertEqual(
-                ThingHappeningsReport.format_timeseries_index_name(date),
-                "blarg_thinghappeningsreport_2020_02_",
+                _thingreport.djelme_index_name(),
+                "blarg_dummy8app_thinghappeningsreport_1999.3.",
             )
 
     def test_format_timeseries_index_pattern__lotsa_parts(self):
         _timeparts = (2020, 2, 14, 0, 1, 2)
         self.assertEqual(
             Dummy8Event.format_timeseries_index_pattern(_timeparts),
-            "dummy8app_dummy8event_2020_02_14_*",
+            "dummy8app_dummy8event_2020.2.14.*",
         )
         self.assertEqual(
             Monthly8Event.format_timeseries_index_pattern(_timeparts),
-            "dummy8evenz_eventlog_2020_02_*",
+            "dummy8evenzdummy8app_eventlog_2020.2.*",
         )
         self.assertEqual(
             ThingHappened.format_timeseries_index_pattern(_timeparts),
-            "dummy8app_happen_2020_*",
+            "dummy8app_happen_2020.*",
         )
         self.assertEqual(
             ThingHappeningsReport.format_timeseries_index_pattern(_timeparts),
-            "blarg_thinghappeningsreport_2020_02_*",
+            "blarg_dummy8app_thinghappeningsreport_2020.2.*",
         )
 
     def test_format_timeseries_index_pattern__some_parts(self):
         _timeparts = (2020, 2, 14)
         self.assertEqual(
             Dummy8Event.format_timeseries_index_pattern(_timeparts),
-            "dummy8app_dummy8event_2020_02_14_*",
+            "dummy8app_dummy8event_2020.2.14.*",
         )
         self.assertEqual(
             Monthly8Event.format_timeseries_index_pattern(_timeparts),
-            "dummy8evenz_eventlog_2020_02_*",
+            "dummy8evenzdummy8app_eventlog_2020.2.*",
         )
         self.assertEqual(
             ThingHappened.format_timeseries_index_pattern(_timeparts),
-            "dummy8app_happen_2020_*",
+            "dummy8app_happen_2020.*",
         )
         self.assertEqual(
             ThingHappeningsReport.format_timeseries_index_pattern(_timeparts),
-            "blarg_thinghappeningsreport_2020_02_*",
+            "blarg_dummy8app_thinghappeningsreport_2020.2.*",
         )
 
     def test_format_timeseries_index_pattern__one_part(self):
         _timeparts = (2020,)
         self.assertEqual(
             Dummy8Event.format_timeseries_index_pattern(_timeparts),
-            "dummy8app_dummy8event_2020_*",
+            "dummy8app_dummy8event_2020.*",
         )
         self.assertEqual(
             Monthly8Event.format_timeseries_index_pattern(_timeparts),
-            "dummy8evenz_eventlog_2020_*",
+            "dummy8evenzdummy8app_eventlog_2020.*",
         )
         self.assertEqual(
             ThingHappened.format_timeseries_index_pattern(_timeparts),
-            "dummy8app_happen_2020_*",
+            "dummy8app_happen_2020.*",
         )
         self.assertEqual(
             ThingHappeningsReport.format_timeseries_index_pattern(_timeparts),
-            "blarg_thinghappeningsreport_2020_*",
+            "blarg_dummy8app_thinghappeningsreport_2020.*",
         )
 
     def test_format_index_pattern_respects_date_format_setting(self):
@@ -141,15 +157,15 @@ class TestNamesAndPatterns(SimpleDjelmeTestCase):
             _timeparts = (2020, 2, 14, 0, 1, 2)
             self.assertEqual(
                 Dummy8Event.format_timeseries_index_pattern(_timeparts),
-                "dummy8app_dummy8event_2020_02_14_00_*",
+                "dummy8app_dummy8event_2020.2.14.0.*",
             )
             self.assertEqual(
                 Monthly8Event.format_timeseries_index_pattern(_timeparts),
-                "dummy8evenz_eventlog_2020_02_*",
+                "dummy8evenzdummy8app_eventlog_2020.2.*",
             )
             self.assertEqual(
                 ThingHappened.format_timeseries_index_pattern(_timeparts),
-                "dummy8app_happen_2020_*",
+                "dummy8app_happen_2020.*",
             )
 
 
@@ -220,9 +236,9 @@ class TestGetIndexTemplate(SimpleDjelmeTestCase):
     ):
         template = Monthly8Event.get_timeseries_template()
         # prefix and recordtype specified in class Meta
-        assert template._template_name == "dummy8evenz_eventlog__template"
+        assert template._template_name == "dummy8evenzdummy8app_eventlog__template"
         # template pattern generated using same options
-        assert "dummy8evenz_eventlog_*" in template.to_dict()["index_patterns"]
+        assert "dummy8evenzdummy8app_eventlog_*" in template.to_dict()["index_patterns"]
 
     def test_inheritance(self):
         class MyBaseRecord(djelme.TimeseriesRecord):
@@ -265,17 +281,17 @@ class TestRecord(MockSaveTestCase):
         p = ThingHappened.record(timestamp=timestamp, thing_id="abc12")
         assert self.mocked_es8_save.call_count == 1
         assert p.timestamp == timestamp
-        assert p.timestamp_parts == "2017.8.21.0.0.0"
+        assert p.timeseries_timeparts == "2017.8.21.0.0.0"
         assert p.thing_id == "abc12"
 
-    @unittest.mock.patch.object(timezone, "now")
-    def test_defaults_timestamp_to_now(self, mock_now):
-        fake_now = dt.datetime(2016, 8, 21)
-        mock_now.return_value = fake_now
-
-        p = ThingHappened.record(thing_id="abc12")
+    def test_defaults_timestamp_to_now(self):
+        _fake_now = dt.datetime(2016, 8, 21, tzinfo=dt.timezone.utc)
+        with unittest.mock.patch(
+            "elasticsearch_metrics.imps.elastic8.utcnow", return_value=_fake_now
+        ):
+            p = ThingHappened.record(thing_id="abc12")
         assert self.mocked_es8_save.call_count == 1
-        assert p.timestamp == fake_now
+        assert p.timestamp == _fake_now
 
 
 class TestSignals(MockSaveTestCase):
@@ -334,7 +350,7 @@ class TestRealCreate(RealElasticTestCase, autosetup_djelme_backends=True):
         )
         assert _fetched_doc
         assert _fetched_doc.timestamp == _doc.timestamp
-        assert _fetched_doc.timestamp_parts == _doc.timestamp_parts
+        assert _fetched_doc.timeseries_timeparts == _doc.timeseries_timeparts
         assert _fetched_doc.thing_id == _doc.thing_id == _thing_id
         assert _fetched_doc.happen_code == _doc.happen_code == _happen_code
 
@@ -356,7 +372,7 @@ class TestRealCreate(RealElasticTestCase, autosetup_djelme_backends=True):
         )
         assert _fetched_doc
         assert _fetched_doc.timestamp == _doc.timestamp
-        assert _fetched_doc.timestamp_parts == _doc.timestamp_parts
+        assert _fetched_doc.timeseries_timeparts == _doc.timeseries_timeparts
         assert _fetched_doc.thing_id == _doc.thing_id == _thing_id
         assert _fetched_doc.happen_code == _doc.happen_code == _happen_code
 
@@ -430,12 +446,12 @@ class TestDailyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
         self.assertEqual(
             _index_names,
             {
-                "dummy8event_1234_05_06_",
-                "dummy8event_1234_05_07_",
-                "dummy8event_1234_06_01_",
-                "dummy8event_1235_05_06_",
-                "dummy8event_2345_06_09_",
-                "dummy8event_2345_07_09_",
+                "dummy8app_dummy8event_1234.5.6.",
+                "dummy8app_dummy8event_1234.5.7.",
+                "dummy8app_dummy8event_1234.6.1.",
+                "dummy8app_dummy8event_1235.5.6.",
+                "dummy8app_dummy8event_2345.6.9.",
+                "dummy8app_dummy8event_2345.7.9.",
             },
         )
 
@@ -492,11 +508,11 @@ class TestMonthlyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
         self.assertEqual(
             _index_names,
             {
-                "eventlog_1234_05_",
-                "eventlog_1234_06_",
-                "eventlog_1235_05_",
-                "eventlog_2345_06_",
-                "eventlog_2345_07_",
+                "dummy8app_eventlog_1234.5.",
+                "dummy8app_eventlog_1234.6.",
+                "dummy8app_eventlog_1235.5.",
+                "dummy8app_eventlog_2345.6.",
+                "dummy8app_eventlog_2345.7.",
             },
         )
 
@@ -553,9 +569,9 @@ class TestYearlyIndexes(RealElasticTestCase, autosetup_djelme_backends=True):
         self.assertEqual(
             _index_names,
             {
-                "happen_1234_",
-                "happen_1235_",
-                "happen_2345_",
+                "dummy8app_happen_1234.",
+                "dummy8app_happen_1235.",
+                "dummy8app_happen_2345.",
             },
         )
 

--- a/elasticsearch_metrics/tests/test_registry.py
+++ b/elasticsearch_metrics/tests/test_registry.py
@@ -12,18 +12,6 @@ class MetricWithAppLabel(elastic6.Metric):
 
 
 class TestTimeseriesTypeRegistry(SimpleTestCase):
-    def test_recordtype_in_app_is_in_registry(self):
-        assert "dummy6app" in djelme_registry.all_recordtypes
-        assert (
-            djelme_registry.all_recordtypes["dummy6app"]["dummy6metric"] is Dummy6Metric
-        )
-
-    def test_recordtype_with_explicit_label_set_is_in_registry(self):
-        assert (
-            djelme_registry.all_recordtypes["dummy6app"]["metricwithapplabel"]
-            is MetricWithAppLabel
-        )
-
     def test_conflicting_recordtype(self):
         with self.assertRaises(RuntimeError):
 

--- a/elasticsearch_metrics/util/timeparts.py
+++ b/elasticsearch_metrics/util/timeparts.py
@@ -46,14 +46,13 @@ def _zeropadded_timeparts(
 
 
 def get_timeparts(
-    when: tuple[int, ...] | datetime.date,
+    when: tuple[int, ...] | datetime.date | str,
     timedepth: int,
 ) -> tuple[int, ...]:
-    return (
-        timeparts_from_date(when, timedepth)
-        if isinstance(when, datetime.date)
-        else tuple(itertools.islice(_zeropadded_timeparts(when), timedepth))
-    )
+    if isinstance(when, datetime.date):
+        return timeparts_from_date(when, timedepth)
+    _each_part = parse_timeparts(when) if isinstance(when, str) else when
+    return tuple(itertools.islice(_zeropadded_timeparts(_each_part), timedepth))
 
 
 def format_full_timeparts(when: tuple[int, ...] | datetime.date) -> str:
@@ -75,7 +74,9 @@ def format_full_timeparts(when: tuple[int, ...] | datetime.date) -> str:
     return TIMEPART_DELIMITER.join(map(str, _parts))
 
 
-def format_timeparts(when: tuple[int, ...] | datetime.date, timedepth: int) -> str:
+def format_timeparts(
+    when: tuple[int, ...] | datetime.date | str, timedepth: int
+) -> str:
     """
     >>> format_timeparts(datetime.date(3000, 7, 12), timedepth=3)
     '3000.7.12'
@@ -115,5 +116,9 @@ if __debug__:
 '3000.9.1.5.2.0'
 >>> format_timeparts(datetime.datetime(3000, 9, 1, 5, 2), timedepth=3)
 '3000.9.1'
+>>> format_timeparts('3000.2.7.9', timedepth=3)
+'3000.2.7'
+>>> format_timeparts('3000.2.7.9', timedepth=5)
+'3000.2.7.9.0'
 """,
     }

--- a/elasticsearch_metrics/util/timeparts.py
+++ b/elasticsearch_metrics/util/timeparts.py
@@ -1,0 +1,119 @@
+import collections
+import datetime
+import itertools
+
+__all__ = (
+    "get_timeparts",
+    "timeparts_from_date",
+    "format_timeparts",
+    "format_full_timeparts",
+    "each_timepart_from_date",
+)
+
+TIMEPART_DELIMITER: str = "."
+
+
+def timeparts_from_date(given_date: datetime.date, timedepth: int) -> tuple[int, ...]:
+    """
+    >>> timeparts_from_date(datetime.date(3456, 7, 8), 2)
+    (3456, 7)
+    >>> timeparts_from_date(datetime.date(3456, 7, 8), 4)
+    (3456, 7, 8, 0)
+    """
+    return tuple(
+        itertools.islice(
+            _zeropadded_timeparts(each_timepart_from_date(given_date)),
+            timedepth,
+        )
+    )
+
+
+def each_timepart_from_date(given_date: datetime.date) -> collections.abc.Iterator[int]:
+    yield given_date.year
+    yield given_date.month
+    yield given_date.day
+    if isinstance(given_date, datetime.datetime):
+        yield given_date.hour
+        yield given_date.minute
+        yield given_date.second
+
+
+def _zeropadded_timeparts(
+    timeparts: collections.abc.Iterable[int],
+) -> collections.abc.Iterator[int]:
+    yield from timeparts
+    yield from itertools.repeat(0)
+
+
+def get_timeparts(
+    when: tuple[int, ...] | datetime.date,
+    timedepth: int,
+) -> tuple[int, ...]:
+    return (
+        timeparts_from_date(when, timedepth)
+        if isinstance(when, datetime.date)
+        else tuple(itertools.islice(_zeropadded_timeparts(when), timedepth))
+    )
+
+
+def format_full_timeparts(when: tuple[int, ...] | datetime.date) -> str:
+    """
+    >>> format_full_timeparts((3000, 2))
+    '3000.2'
+    >>> format_full_timeparts(datetime.date(3000, 7, 12))
+    '3000.7.12'
+    >>> format_full_timeparts(datetime.datetime(3000, 9, 1))
+    '3000.9.1.0.0.0'
+    """
+    _parts = (
+        timeparts_from_date(
+            when, timedepth=(6 if isinstance(when, datetime.datetime) else 3)
+        )
+        if isinstance(when, datetime.date)
+        else when
+    )
+    return TIMEPART_DELIMITER.join(map(str, _parts))
+
+
+def format_timeparts(when: tuple[int, ...] | datetime.date, timedepth: int) -> str:
+    """
+    >>> format_timeparts(datetime.date(3000, 7, 12), timedepth=3)
+    '3000.7.12'
+    >>> format_timeparts(datetime.date(3000, 7, 12), timedepth=2)
+    '3000.7'
+    >>> format_timeparts(datetime.date(3000, 7, 12), timedepth=1)
+    '3000'
+    """
+    return format_full_timeparts(get_timeparts(when, timedepth))
+
+
+def parse_timeparts(timepart_str: str) -> tuple[int, ...]:
+    """
+    >>> parse_timeparts('1.2.3')
+    (1, 2, 3)
+    >>> parse_timeparts('1999.12.7.9')
+    (1999, 12, 7, 9)
+    >>> parse_timeparts('')
+    ()
+    """
+    _split_parts = timepart_str.split(TIMEPART_DELIMITER)
+    if not any(_split_parts):
+        return ()
+    return tuple(map(int, _split_parts))
+
+
+if __debug__:
+    __test__ = {
+        "format_timeparts": """
+>>> format_timeparts((3000, 2, 7, 9), timedepth=2)
+'3000.2'
+>>> format_timeparts((3000, 2), timedepth=1)
+'3000'
+>>> format_timeparts((3000, 2, 7, 9), timedepth=5)
+'3000.2.7.9.0'
+>>> format_timeparts(datetime.datetime(3000, 9, 1, 5, 2), timedepth=6)
+'3000.9.1.5.2.0'
+>>> format_timeparts(datetime.datetime(3000, 9, 1, 5, 2), timedepth=3)
+'3000.9.1'
+""",
+    }

--- a/elasticsearch_metrics/util/timeseries_naming.py
+++ b/elasticsearch_metrics/util/timeseries_naming.py
@@ -174,12 +174,15 @@ def format_index_pattern_for_timerange(
 ) -> str:
     """get an index-name pattern for all indexes within a timepart range
 
+    choose a wildcard based on shared timeparts
     >>> format_index_pattern_for_timerange('ap', 'rt',
     ...     (5020, 2, 2), (5020, 12, 20), timedepth=2)
     'ap_rt_5020_*'
     >>> format_index_pattern_for_timerange('ap', 'rt',
     ...     (5020, 2, 2), (5020, 2, 20), timedepth=2)
     'ap_rt_5020_02_*'
+
+    with `include_less_granular=True` 
     >>> format_index_pattern_for_timerange('ap', 'rt',
     ...     (5020, 2, 2), (5020, 2, 20), timedepth=2, include_less_granular=True)
     'ap_rt_,ap_rt_5020_,ap_rt_5020_02_*'
@@ -475,3 +478,10 @@ def semverlike_timeparts(when: tuple[int, ...] | datetime.date, timedepth: int) 
     '3000.9.1'
     """
     return full_semverlike_timeparts(_whenparts(when, timedepth))
+
+
+if __debug__:
+    __test__ = {
+        'format_index_pattern_for_timerange': '''
+'''
+    }

--- a/elasticsearch_metrics/util/timeseries_naming.py
+++ b/elasticsearch_metrics/util/timeseries_naming.py
@@ -31,7 +31,7 @@ TimeseriesIndexNamePattern = tuple[str, str, tuple[int, ...]]
 
 
 def format_index_name(
-    prefix: str,
+    app_label: str,
     recordtype: str,
     timeparts: collections.abc.Sequence[int] = (),  # empty () -- all time
     max_timedepth: int | None = None,
@@ -43,7 +43,7 @@ def format_index_name(
     'a_rt_9999_22_00_'
     """
     _parts = [
-        format_namepart(prefix),
+        format_namepart(app_label),
         format_namepart(recordtype),
     ]
     if timeparts:
@@ -60,21 +60,21 @@ def format_index_name(
 def format_index_name_for_date(
     given_date: datetime.date,
     *,
-    prefix: str,
+    app_label: str,
     recordtype: str,
     timedepth: int,
 ) -> str:
     """get a full/specific index name, no wildcards or lists
-    >>> format_index_name_for_date(datetime.date(9876,5,4), prefix='ap', recordtype='rt', timedepth=2)
+    >>> format_index_name_for_date(datetime.date(9876,5,4), app_label='ap', recordtype='rt', timedepth=2)
     'ap_rt_9876_05_'
     """
     return format_index_name(
-        prefix, recordtype, timeparts_from_date(given_date, timedepth)
+        app_label, recordtype, timeparts_from_date(given_date, timedepth)
     )
 
 
 def format_index_pattern(
-    prefix: str,
+    app_label: str,
     recordtype: str,
     timeparts: collections.abc.Sequence[int] = (),  # empty () -- all time
     max_timedepth: int | None = None,
@@ -87,7 +87,7 @@ def format_index_pattern(
     >>> format_index_pattern('a', 'rt', (1, 2, 3, 4, 5), max_timedepth=3)
     'a_rt_01_02_03_*'
     """
-    return f"{format_index_name(prefix, recordtype, timeparts, max_timedepth)}*"
+    return f"{format_index_name(app_label, recordtype, timeparts, max_timedepth)}*"
 
 
 def _each_timeparts_for_timerange(
@@ -135,7 +135,7 @@ def _each_timeparts_for_timerange(
 
 
 def _each_indexpattern_for_timerange(
-    prefix: str,
+    app_label: str,
     recordtype: str,
     from_timeparts: collections.abc.Sequence[int],
     until_timeparts: collections.abc.Sequence[int],
@@ -156,13 +156,13 @@ def _each_indexpattern_for_timerange(
             # intuitively, zero is a fine value for any datepart except the second and third
             continue  # skip month zero and day zero
         if _is_wildcard:
-            yield format_index_pattern(prefix, recordtype, _timeparts)
+            yield format_index_pattern(app_label, recordtype, _timeparts)
         else:
-            yield format_index_name(prefix, recordtype, _timeparts)
+            yield format_index_name(app_label, recordtype, _timeparts)
 
 
 def format_index_pattern_for_timerange(
-    prefix: str,
+    app_label: str,
     recordtype: str,
     from_timeparts: collections.abc.Sequence[int],
     until_timeparts: collections.abc.Sequence[int],
@@ -209,7 +209,7 @@ def format_index_pattern_for_timerange(
     """
     return ",".join(
         _each_indexpattern_for_timerange(
-            prefix,
+            app_label,
             recordtype,
             from_timeparts,
             until_timeparts,
@@ -222,7 +222,7 @@ def format_index_pattern_for_timerange(
 
 
 def format_index_pattern_for_range(
-    prefix: str,
+    app_label: str,
     recordtype: str,
     from_when: tuple[int, ...] | datetime.date,
     until_when: tuple[int, ...] | datetime.date,
@@ -252,7 +252,7 @@ def format_index_pattern_for_range(
     'ap_rt_200_05_*'
     """
     return format_index_pattern_for_timerange(
-        prefix=prefix,
+        app_label=app_label,
         recordtype=recordtype,
         from_timeparts=_whenparts(from_when, timedepth),
         until_timeparts=_whenparts(until_when, timedepth),
@@ -263,7 +263,7 @@ def format_index_pattern_for_range(
 
 
 def format_template_name(
-    prefix: str,
+    app_label: str,
     recordtype: str,
 ) -> str:
     """
@@ -271,7 +271,7 @@ def format_template_name(
     'blah_fleh__template'
     """
     return _DELIMITER.join(
-        (format_namepart(prefix), format_namepart(recordtype), _TEMPLATE_NAME_SUFFIX)
+        (format_namepart(app_label), format_namepart(recordtype), _TEMPLATE_NAME_SUFFIX)
     )
 
 

--- a/elasticsearch_metrics/util/timeseries_naming.py
+++ b/elasticsearch_metrics/util/timeseries_naming.py
@@ -8,21 +8,26 @@ from __future__ import annotations
 
 __all__ = (
     "format_index_name",
-    "parse_index_name",
+    "format_index_name_for_date",
     "format_index_pattern",
-    "parse_index_pattern",
+    "format_index_pattern_for_range",
     "format_namepart",
     "format_template_name",
-    "timeparts_from_date",
 )
 
 import collections
-from collections.abc import Iterator
 import datetime
 import itertools
 
+from .timeparts import (
+    timeparts_from_date,
+    get_timeparts,
+    format_full_timeparts,
+    parse_timeparts,
+    TIMEPART_DELIMITER,
+)
+
 _DELIMITER: str = "_"
-_TIMEPART_MIN_LEN: int = 2
 _TEMPLATE_NAME_SUFFIX = "_template"
 _DEFAULT_PATTERN_FANOUT: int = 3
 
@@ -33,27 +38,36 @@ TimeseriesIndexNamePattern = tuple[str, str, tuple[int, ...]]
 def format_index_name(
     app_label: str,
     recordtype: str,
-    timeparts: collections.abc.Sequence[int] = (),  # empty () -- all time
+    timeparts: str | collections.abc.Sequence[int] = (),  # empty () -- all time
     max_timedepth: int | None = None,
 ) -> str:
     """get a full/specific index name, no wildcards or lists
+
     >>> format_index_name('a', 'rt', (9999, 22))
-    'a_rt_9999_22_'
+    'a_rt_9999.22.'
     >>> format_index_name('a', 'rt', (9999, 22, 0))
-    'a_rt_9999_22_00_'
+    'a_rt_9999.22.0.'
+    >>> format_index_name('app', 'type', '500.2.3')
+    'app_type_500.2.3.'
+    >>> format_index_name('app', 'type', ())
+    'app_type_'
     """
     _parts = [
         format_namepart(app_label),
         format_namepart(recordtype),
     ]
-    if timeparts:
+    _timeparts_seq = (
+        parse_timeparts(timeparts) if isinstance(timeparts, str) else timeparts
+    )
+    if _timeparts_seq:
         _trimmed_timeparts = (
-            timeparts if (max_timedepth is None) else timeparts[:max_timedepth]
+            _timeparts_seq
+            if (max_timedepth is None)
+            else _timeparts_seq[:max_timedepth]
         )
         _parts.append(_format_timename(*_trimmed_timeparts))
-    _parts.append(
-        ""
-    )  # always end with the delimiter, to match wildcard pattern `foo_bar_123_*`
+    else:
+        _parts.append("")  # add trailing delimiter for unambiguous pattern matching
     return _DELIMITER.join(_parts)
 
 
@@ -66,7 +80,7 @@ def format_index_name_for_date(
 ) -> str:
     """get a full/specific index name, no wildcards or lists
     >>> format_index_name_for_date(datetime.date(9876,5,4), app_label='ap', recordtype='rt', timedepth=2)
-    'ap_rt_9876_05_'
+    'ap_rt_9876.5.'
     """
     return format_index_name(
         app_label, recordtype, timeparts_from_date(given_date, timedepth)
@@ -76,16 +90,20 @@ def format_index_name_for_date(
 def format_index_pattern(
     app_label: str,
     recordtype: str,
-    timeparts: collections.abc.Sequence[int] = (),  # empty () -- all time
+    timeparts: str | collections.abc.Sequence[int] = (),  # empty () -- all time
     max_timedepth: int | None = None,
 ) -> str:
     """get an index-name pattern for all indexes within the given timeparts
     >>> format_index_pattern('a', 'rt', (9999,22))
-    'a_rt_9999_22_*'
+    'a_rt_9999.22.*'
     >>> format_index_pattern('a', 'rt', (1, 2, 3, 4, 5))
-    'a_rt_01_02_03_04_05_*'
+    'a_rt_1.2.3.4.5.*'
     >>> format_index_pattern('a', 'rt', (1, 2, 3, 4, 5), max_timedepth=3)
-    'a_rt_01_02_03_*'
+    'a_rt_1.2.3.*'
+    >>> format_index_pattern('a', 'rt', '5.6.7.8', max_timedepth=3)
+    'a_rt_5.6.7.*'
+    >>> format_index_pattern('a', 'rt', ())
+    'a_rt_*'
     """
     return f"{format_index_name(app_label, recordtype, timeparts, max_timedepth)}*"
 
@@ -96,7 +114,7 @@ def _each_timeparts_for_timerange(
     *,
     timedepth: int,
     max_fanout: int,
-    include_less_granular: bool,
+    include_less_timedepth: bool,
 ) -> collections.abc.Generator[tuple[tuple[int, ...], bool]]:
     """
     yield (timeparts, is_wildcard) tuples
@@ -106,7 +124,7 @@ def _each_timeparts_for_timerange(
         return
     _from_part, *_from_rest = from_timeparts or [0]
     _until_part, *_until_rest = until_timeparts or [0]
-    if include_less_granular:
+    if include_less_timedepth:
         yield (), False  # include less-granular non-wildcard index, if it exists
     if _from_part == _until_part:
         for _rest_parts, _is_wildcard in _each_timeparts_for_timerange(
@@ -114,7 +132,7 @@ def _each_timeparts_for_timerange(
             _until_rest,
             timedepth=timedepth - 1,
             max_fanout=max_fanout,
-            include_less_granular=include_less_granular,
+            include_less_timedepth=include_less_timedepth,
         ):
             yield (_from_part, *_rest_parts), _is_wildcard
     elif 0 < (_until_part - _from_part) <= max_fanout:  # not too far apart
@@ -127,7 +145,7 @@ def _each_timeparts_for_timerange(
                 _until_rest,
                 timedepth=timedepth - 1,
                 max_fanout=max_fanout,
-                include_less_granular=include_less_granular,
+                include_less_timedepth=include_less_timedepth,
             ):
                 yield (_until_part, *_rest_parts), _is_wildcard
     else:  # too far apart
@@ -142,7 +160,7 @@ def _each_indexpattern_for_timerange(
     *,
     timedepth: int,
     max_fanout: int,
-    include_less_granular: bool,
+    include_less_timedepth: bool,
     only_datelike: bool,
 ) -> collections.abc.Generator[str]:
     for _timeparts, _is_wildcard in _each_timeparts_for_timerange(
@@ -150,7 +168,7 @@ def _each_indexpattern_for_timerange(
         until_timeparts,
         timedepth=timedepth,
         max_fanout=max_fanout,
-        include_less_granular=include_less_granular,
+        include_less_timedepth=include_less_timedepth,
     ):
         if only_datelike and (0 in _timeparts[1:3]):
             # intuitively, zero is a fine value for any datepart except the second and third
@@ -161,7 +179,7 @@ def _each_indexpattern_for_timerange(
             yield format_index_name(app_label, recordtype, _timeparts)
 
 
-def format_index_pattern_for_timerange(
+def format_index_pattern_for_timeparts_range(
     app_label: str,
     recordtype: str,
     from_timeparts: collections.abc.Sequence[int],
@@ -169,46 +187,33 @@ def format_index_pattern_for_timerange(
     *,
     timedepth: int,
     max_fanout: int = _DEFAULT_PATTERN_FANOUT,
-    include_less_granular: bool = False,
+    include_less_timedepth: bool = False,
     only_datelike: bool = False,
 ) -> str:
     """get an index-name pattern for all indexes within a timepart range
 
     choose a wildcard based on shared timeparts
-    >>> format_index_pattern_for_timerange('ap', 'rt',
+    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
     ...     (5020, 2, 2), (5020, 12, 20), timedepth=2)
-    'ap_rt_5020_*'
-    >>> format_index_pattern_for_timerange('ap', 'rt',
+    'ap_rt_5020.*'
+    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
     ...     (5020, 2, 2), (5020, 2, 20), timedepth=2)
-    'ap_rt_5020_02_*'
+    'ap_rt_5020.2.*'
 
-    with `include_less_granular=True` 
-    >>> format_index_pattern_for_timerange('ap', 'rt',
-    ...     (5020, 2, 2), (5020, 2, 20), timedepth=2, include_less_granular=True)
-    'ap_rt_,ap_rt_5020_,ap_rt_5020_02_*'
-    >>> format_index_pattern_for_timerange('ap', 'rt',
-    ...     (5020, 2, 1), (5020, 3), timedepth=2)
-    'ap_rt_5020_02_*'
-    >>> format_index_pattern_for_timerange('ap', 'rt',
-    ...     (5020, 2, 2), (5020, 2, 3), timedepth=3)
-    'ap_rt_5020_02_02_*'
-    >>> format_index_pattern_for_timerange('ap', 'rt',
+    if unshared timeparts close enough, enumerate possibilities to narrow the wildcard
+    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
     ...     (5020, 2, 2), (5020, 3, 3), timedepth=3)
-    'ap_rt_5020_02_*,ap_rt_5020_03_00_*,ap_rt_5020_03_01_*,ap_rt_5020_03_02_*'
-    >>> format_index_pattern_for_timerange('ap', 'rt',
+    'ap_rt_5020.2.*,ap_rt_5020.3.0.*,ap_rt_5020.3.1.*,ap_rt_5020.3.2.*'
+
+    with `only_datelike=True`, exclude patterns with zero in "month" or "day"
+    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
     ...     (5020, 2, 2), (5022, 3, 3), timedepth=3, only_datelike=True)
-    'ap_rt_5020_*,ap_rt_5021_*,ap_rt_5022_01_*,ap_rt_5022_02_*,ap_rt_5022_03_01_*,ap_rt_5022_03_02_*'
-    >>> format_index_pattern_for_timerange('ap', 'rt',
-    ...     (5020, 2, 2), (5022,), timedepth=3)
-    'ap_rt_5020_*,ap_rt_5021_*'
-    >>> format_index_pattern_for_timerange('a', 'b', (1999,), (2002,), timedepth=2)
-    'a_b_1999_*,a_b_2000_*,a_b_2001_*'
-    >>> format_index_pattern_for_timerange('a', 'b',
-    ...     (1999, 27, 17, 0, 3), (1999, 27, 17, 0, 223,), timedepth=5)
-    'a_b_1999_27_17_00_*'
-    >>> format_index_pattern_for_timerange('a', 'b',
-    ...     (1999, 27, 17, 0, 3), (2002, 117, 17, 0, 3), timedepth=5)
-    'a_b_1999_*,a_b_2000_*,a_b_2001_*,a_b_2002_*'
+    'ap_rt_5020.*,ap_rt_5021.*,ap_rt_5022.1.*,ap_rt_5022.2.*,ap_rt_5022.3.1.*,ap_rt_5022.3.2.*'
+
+    with `include_less_timedepth=True`, include patterns for indexes created with lower timedepths
+    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
+    ...     (5020, 2, 2), (5020, 2, 20), timedepth=2, include_less_timedepth=True)
+    'ap_rt_,ap_rt_5020.,ap_rt_5020.2.*'
     """
     return ",".join(
         _each_indexpattern_for_timerange(
@@ -218,7 +223,7 @@ def format_index_pattern_for_timerange(
             until_timeparts,
             timedepth=timedepth,
             max_fanout=max_fanout,
-            include_less_granular=include_less_granular,
+            include_less_timedepth=include_less_timedepth,
             only_datelike=only_datelike,
         )
     )
@@ -230,37 +235,38 @@ def format_index_pattern_for_range(
     from_when: tuple[int, ...] | datetime.date,
     until_when: tuple[int, ...] | datetime.date,
     timedepth: int,
-    include_less_granular: bool = False,
+    include_less_timedepth: bool = False,
 ) -> str:
     """get an index-name pattern for all indexes within a date range
+
     >>> format_index_pattern_for_range('ap', 'rt',
     ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 8),
     ...     timedepth=2)
-    'ap_rt_2050_05_*'
+    'ap_rt_2050.5.*'
     >>> format_index_pattern_for_range('ap', 'rt',
     ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 8),
-    ...     timedepth=2, include_less_granular=True)
-    'ap_rt_,ap_rt_2050_,ap_rt_2050_05_*'
+    ...     timedepth=2, include_less_timedepth=True)
+    'ap_rt_,ap_rt_2050.,ap_rt_2050.5.*'
     >>> format_index_pattern_for_range('ap', 'rt',
     ...     datetime.date(2050, 5, 5), (2050, 5, 8, 10),
     ...     timedepth=3)
-    'ap_rt_2050_05_05_*,ap_rt_2050_05_06_*,ap_rt_2050_05_07_*'
+    'ap_rt_2050.5.5.*,ap_rt_2050.5.6.*,ap_rt_2050.5.7.*'
     >>> format_index_pattern_for_range('ap', 'rt',
     ...     (2050, 5, 5, 3), datetime.date(2050, 5, 8),
-    ...     timedepth=3, include_less_granular=True)
-    'ap_rt_,ap_rt_2050_,ap_rt_2050_05_,ap_rt_2050_05_05_*,ap_rt_2050_05_06_*,ap_rt_2050_05_07_*'
+    ...     timedepth=3, include_less_timedepth=True)
+    'ap_rt_,ap_rt_2050.,ap_rt_2050.5.,ap_rt_2050.5.5.*,ap_rt_2050.5.6.*,ap_rt_2050.5.7.*'
     >>> format_index_pattern_for_range('ap', 'rt',
     ...     (200, 5), datetime.date(200, 5, 8),
     ...     timedepth=3)
-    'ap_rt_200_05_*'
+    'ap_rt_200.5.*'
     """
-    return format_index_pattern_for_timerange(
+    return format_index_pattern_for_timeparts_range(
         app_label=app_label,
         recordtype=recordtype,
-        from_timeparts=_whenparts(from_when, timedepth),
-        until_timeparts=_whenparts(until_when, timedepth),
+        from_timeparts=get_timeparts(from_when, timedepth),
+        until_timeparts=get_timeparts(until_when, timedepth),
         timedepth=timedepth,
-        include_less_granular=include_less_granular,
+        include_less_timedepth=include_less_timedepth,
         only_datelike=True,
     )
 
@@ -282,206 +288,45 @@ def format_namepart(namepart: str) -> str:
     return namepart.replace(_DELIMITER, "").lower()
 
 
-def parse_index_name(given_name: str) -> TimeseriesIndexNamePattern:
-    """
-    >>> parse_index_name('blah_fleh_1123_58')
-    ('blah', 'fleh', (1123, 58))
-    >>> parse_index_name('ap_rt_2001')
-    ('ap', 'rt', (2001,))
-    """
-    _prefix, _recordtype, _timename = given_name.split(_DELIMITER, maxsplit=2)
-    return (_prefix, _recordtype, tuple(_parse_timename(_timename)))
-
-
-def parse_index_pattern(given_pattern: str) -> TimeseriesIndexNamePattern:
-    """
-    >>> parse_index_pattern('blah_fleh_1123_58')
-    ('blah', 'fleh', (1123, 58))
-    >>> parse_index_pattern('ap_rt_2001_')
-    ('ap', 'rt', (2001,))
-    >>> parse_index_pattern('a_b_7766_5_*')
-    ('a', 'b', (7766, 5))
-    >>> parse_index_pattern('a_b_7766_555_*')
-    ('a', 'b', (7766, 555))
-    """
-    _prefix, _recordtype, _timename = given_pattern.split(_DELIMITER, maxsplit=2)
-    return (_prefix, _recordtype, tuple(_parse_timename(_timename)))
-
-
-def _timerange_part_overlap(
-    start: collections.abc.Iterable[int],
-    end: collections.abc.Iterable[int],
-    max_overlap: int,
-) -> collections.abc.Iterable[int]:
-    return tuple(itertools.islice(_shared_timeparts(start, end), max_overlap))
-
-
-def _shared_timeparts(
-    start: collections.abc.Iterable[int], end: collections.abc.Iterable[int]
-) -> Iterator[int]:
-    for _startpart, _endpart in zip(start, end, strict=False):
-        if _startpart != _endpart:
-            break
-        yield _startpart
-
-
 def _format_timename(*timeparts: int) -> str:
     """
     >>> _format_timename(1999)
-    '1999'
+    '1999.'
     >>> _format_timename(2345)
-    '2345'
+    '2345.'
 
     use with any series of integers
     >>> _format_timename(1234, 5, 6, 7)
-    '1234_05_06_07'
+    '1234.5.6.7.'
     >>> _format_timename(2345, 6, 2, 17, 4200)
-    '2345_06_02_17_4200'
+    '2345.6.2.17.4200.'
     >>> _format_timename(6, 1, 8, 2)
-    '06_01_08_02'
+    '6.1.8.2.'
     >>> _format_timename(2345, 0)
-    '2345_00'
+    '2345.0.'
     """
-    return _DELIMITER.join(map(_format_timepart, timeparts))
-
-
-def _parse_timename(given_timename: str) -> Iterator[int]:
-    """
-    >>> list(_parse_timename('7766_555_04'))
-    [7766, 555, 4]
-    >>> list(_parse_timename('7766_555'))
-    [7766, 555]
-    >>> list(_parse_timename('7766_555_'))
-    [7766, 555]
-    """
-    for _part in given_timename.rstrip("*").rstrip(_DELIMITER).split(_DELIMITER):
-        yield int(_part)
-
-
-def timename_from_datestr(given_date: str, timedepth: int) -> str:
-    """
-    >>> timename_from_datestr('2345-06-07', 1)
-    '2345'
-    >>> timename_from_datestr('2345-06-07T01:00:00+00:00', 2)
-    '2345_06'
-    >>> timename_from_datestr('2345-06-07', 3)
-    '2345_06_07'
-    >>> timename_from_datestr('2345-06-07', 4)
-    '2345_06_07_00'
-    >>> timename_from_datestr('2345-06-07', 5)
-    '2345_06_07_00_00'
-    >>> timename_from_datestr('2345-06-07', 6)
-    '2345_06_07_00_00_00'
-    >>> timename_from_datestr('2345-06-07T01:01:02+00:00', 7)
-    '2345_06_07_01_01_02'
-    """
-    return timename_from_date(
-        datetime.datetime.fromisoformat(given_date),
-        timedepth=timedepth,
-    )
-
-
-def timename_from_date(given_date: datetime.date, timedepth: int) -> str:
-    """
-    >>> timename_from_date(datetime.date(3456, 7, 8), 2)
-    '3456_07'
-    """
-    _timeparts = itertools.islice(_each_timepart_from_date(given_date), timedepth)
-    return _format_timename(*_timeparts)
-
-
-def timeparts_from_date(given_date: datetime.date, timedepth: int) -> tuple[int, ...]:
-    """
-    >>> timeparts_from_date(datetime.date(3456, 7, 8), 2)
-    (3456, 7)
-    >>> timeparts_from_date(datetime.date(3456, 7, 8), 4)
-    (3456, 7, 8, 0)
-    """
-    return tuple(
-        itertools.islice(
-            _zeropadded_timeparts(_each_timepart_from_date(given_date)),
-            timedepth,
-        )
-    )
-
-
-def _each_timepart_from_date(given_date: datetime.date) -> Iterator[int]:
-    yield given_date.year
-    yield given_date.month
-    yield given_date.day
-    if isinstance(given_date, datetime.datetime):
-        yield given_date.hour
-        yield given_date.minute
-        yield given_date.second
-
-
-def _zeropadded_timeparts(
-    timeparts: collections.abc.Iterable[int],
-) -> collections.abc.Iterator[int]:
-    yield from timeparts
-    yield from itertools.repeat(0)
-
-
-def _format_timepart(timepart: int) -> str:
-    return f"{timepart:0{_TIMEPART_MIN_LEN}}"
-
-
-def _whenparts(
-    when: tuple[int, ...] | datetime.date,
-    timedepth: int,
-) -> tuple[int, ...]:
-    return (
-        timeparts_from_date(when, timedepth)
-        if isinstance(when, datetime.date)
-        else tuple(itertools.islice(_zeropadded_timeparts(when), timedepth))
-    )
-
-
-def full_semverlike_timeparts(when: tuple[int, ...] | datetime.date) -> str:
-    """
-    >>> full_semverlike_timeparts((3000, 2))
-    '3000.2'
-    >>> full_semverlike_timeparts(datetime.date(3000, 7, 12))
-    '3000.7.12'
-    >>> full_semverlike_timeparts(datetime.datetime(3000, 9, 1))
-    '3000.9.1.0.0.0'
-    """
-    _parts = (
-        timeparts_from_date(
-            when, timedepth=(6 if isinstance(when, datetime.datetime) else 3)
-        )
-        if isinstance(when, datetime.date)
-        else when
-    )
-    return ".".join(map(str, _parts))
-
-
-def semverlike_timeparts(when: tuple[int, ...] | datetime.date, timedepth: int) -> str:
-    """
-    >>> semverlike_timeparts((3000, 2, 7, 9), timedepth=2)
-    '3000.2'
-    >>> semverlike_timeparts((3000, 2), timedepth=1)
-    '3000'
-    >>> semverlike_timeparts((3000, 2, 7, 9), timedepth=5)
-    '3000.2.7.9.0'
-
-    >>> semverlike_timeparts(datetime.date(3000, 7, 12), timedepth=3)
-    '3000.7.12'
-    >>> semverlike_timeparts(datetime.date(3000, 7, 12), timedepth=2)
-    '3000.7'
-    >>> semverlike_timeparts(datetime.date(3000, 7, 12), timedepth=1)
-    '3000'
-
-    >>> semverlike_timeparts(datetime.datetime(3000, 9, 1, 5, 2), timedepth=6)
-    '3000.9.1.5.2.0'
-    >>> semverlike_timeparts(datetime.datetime(3000, 9, 1, 5, 2), timedepth=3)
-    '3000.9.1'
-    """
-    return full_semverlike_timeparts(_whenparts(when, timedepth))
+    return f"{format_full_timeparts(timeparts)}{TIMEPART_DELIMITER}"
 
 
 if __debug__:
     __test__ = {
-        'format_index_pattern_for_timerange': '''
-'''
+        "format_index_pattern_for_timeparts_range": """
+>>> format_index_pattern_for_timeparts_range('ap', 'rt',
+...     (5020, 2, 1), (5020, 3), timedepth=2)
+'ap_rt_5020.2.*'
+>>> format_index_pattern_for_timeparts_range('ap', 'rt',
+...     (5020, 2, 2), (5020, 2, 3), timedepth=3)
+'ap_rt_5020.2.2.*'
+>>> format_index_pattern_for_timeparts_range('ap', 'rt',
+...     (5020, 2, 2), (5022,), timedepth=3)
+'ap_rt_5020.*,ap_rt_5021.*'
+>>> format_index_pattern_for_timeparts_range('a', 'b', (1999,), (2002,), timedepth=2)
+'a_b_1999.*,a_b_2000.*,a_b_2001.*'
+>>> format_index_pattern_for_timeparts_range('a', 'b',
+...     (1999, 27, 17, 0, 3), (1999, 27, 17, 0, 223,), timedepth=5)
+'a_b_1999.27.17.0.*'
+>>> format_index_pattern_for_timeparts_range('a', 'b',
+...     (1999, 27, 17, 0, 3), (2002, 117, 17, 0, 3), timedepth=5)
+'a_b_1999.*,a_b_2000.*,a_b_2001.*,a_b_2002.*'
+""",
     }


### PR DESCRIPTION
- improve test setup/teardown, isolating test runs with index-name prefixes
- index `CyclicRecord` by `cycle_coverage`, not by time created
- more consistent date formatting in index names (use semver-like `2026.3.31` to align with the `timeseries_timeparts` field)
- move `djelme_registry.all_recordtypes` to semi-private attr (require interacting with registry thru methods, not direct access to mutable dict)
- improve docs