### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Changes:
 Bug fixes:
 
 * Pin to elasticsearch-dsl>=6.0.0,<6.3.0 because version 6.3.0
-  introduces an incompatiblity.
+  introduces an incompatibility.
 
 ## 4.0.3 (2018-10-15)
 

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -580,7 +580,7 @@ class TimeseriesRecord(BaseDjelmeRecord):
         :raise: IndexTemplateNotFoundError if index template does not exist.
         :raise: IndexTemplateOutOfSyncError if mappings, settings, or index patterns
             are out of sync.
-        :return: True if index template exsits and mappings, settings, and index patterns
+        :return: True if index template exists and mappings, settings, and index patterns
             are in sync.
         """
         client = cls._get_connection(using)
@@ -769,7 +769,7 @@ class DjelmeElastic8Backend:
     }
 
     backend_name: str
-    imp_kwargs: dict[str, str]  # pass-thru to elasticsearch connection kwargs
+    imp_kwargs: dict[str, str]  # pass-through to elasticsearch connection kwargs
 
     def djelme_backend_name(self) -> str:  # for ProtoDjelmeBackend
         return self.backend_name


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell`
```
./CHANGELOG.md:24: incompatiblity ==> incompatibility
./elasticsearch_metrics/imps/elastic6.py:198: exsits ==> exists, exist
./elasticsearch_metrics/imps/elastic8.py:583: exsits ==> exists, exist
./elasticsearch_metrics/imps/elastic8.py:772: pass-thru ==> pass-through, pass through, passthrough
```
% `codespell --write-changes` 