### PR TITLE
Ruff rules for pyupgrade

### DIFF
--- a/elasticsearch_metrics/management/color.py
+++ b/elasticsearch_metrics/management/color.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Sets up the terminal color scheme.
 

--- a/elasticsearch_metrics/management/commands/djelme_backend_check.py
+++ b/elasticsearch_metrics/management/commands/djelme_backend_check.py
@@ -36,11 +36,11 @@ class Command(BaseCommand):
 
         if out_of_sync_count:
             self.stdout.write(
-                "{} index template(s) not set up.".format(out_of_sync_count),
+                f"{out_of_sync_count} index template(s) not set up.",
                 style.ERROR,
             )
             cmd = colorize("python manage.py djelme_backend_setup", opts=("bold",))
-            self.stdout.write("Run {cmd} to set up index templates.".format(cmd=cmd))
+            self.stdout.write(f"Run {cmd} to set up index templates.")
             raise CommandError(1)
         else:
             self.stdout.write("All djelme recordtypes set up.", style.SUCCESS)

--- a/elasticsearch_metrics/management/commands/djelme_backend_setup.py
+++ b/elasticsearch_metrics/management/commands/djelme_backend_setup.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
         )
         for _app_label in _app_labels:
             self.stdout.write(
-                "Syncing recordtypes for app: '{}'".format(_app_label),
+                f"Syncing recordtypes for app: '{_app_label}'",
                 style.MIGRATE_HEADING,
             )
             try:

--- a/elasticsearch_metrics/management/commands/djelme_backend_types.py
+++ b/elasticsearch_metrics/management/commands/djelme_backend_types.py
@@ -21,9 +21,7 @@ class Command(BaseCommand):
         else:
             app_labels = list(djelme_registry.each_app_label())
         for app_label in app_labels:
-            self.stdout.write(
-                "Recordtypes for '{}':".format(app_label), style.MIGRATE_HEADING
-            )
+            self.stdout.write(f"Recordtypes for '{app_label}':", style.MIGRATE_HEADING)
             for _recordtype in djelme_registry.each_recordtype(app_label=app_label):
                 _recordtype_name = style.TYPENAME(_recordtype.__name__)
                 self.stdout.write(f"{app_label}.{_recordtype_name}")

--- a/elasticsearch_metrics/registry.py
+++ b/elasticsearch_metrics/registry.py
@@ -79,12 +79,8 @@ class _DjelmeRegistry:
         if recordtype_name in app_recordtypes:
             # Raise an error for conflicting recordtype names (same behavior as apps.register_model)
             raise RuntimeError(
-                "Conflicting '{}' recordtypes in application '{}': {} and {}.".format(
-                    recordtype_name,
-                    _app_label,
-                    app_recordtypes[recordtype_name],
-                    recordtype,
-                )
+                f"Conflicting '{recordtype_name}' recordtypes in application "
+                f"'{_app_label}': {app_recordtypes[recordtype_name]} and {recordtype}."
             )
         app_recordtypes[recordtype_name] = recordtype
         self._imp_by_recordtype[recordtype] = imp_module_name
@@ -117,9 +113,7 @@ class _DjelmeRegistry:
             return app_recordtypes[format_namepart(recordtype_name)]
         except KeyError as e:
             raise LookupError(
-                "App '{}' doesn't have a '{}' metric.".format(
-                    app_label, recordtype_name
-                )
+                f"App '{app_label}' doesn't have a '{recordtype_name}' metric."
             ) from e
 
     def get_recordtype_app_label(self, recordtype: type) -> str | None:
@@ -181,8 +175,7 @@ class _DjelmeRegistry:
         apps.check_apps_ready()  # ensure django setup done
         _app_labels = [app_label] if app_label else self._all_recordtypes.keys()
         for _app_label in _app_labels:
-            for _recordtype in self._get_recordtypes_for_app(_app_label).values():
-                yield _recordtype
+            yield from self._get_recordtypes_for_app(_app_label).values()
 
     def each_backend_settings(
         self,
@@ -246,9 +239,7 @@ class _DjelmeRegistry:
         self, app_label: str
     ) -> collections.abc.Mapping[str, type]:
         if app_label not in self._all_recordtypes:
-            raise LookupError(
-                "No recordtypes found in app with label '{}'.".format(app_label)
-            )
+            raise LookupError(f"No recordtypes found in app with label '{app_label}'.")
         return self._all_recordtypes[app_label]
 
 


### PR DESCRIPTION
# https://docs.astral.sh/ruff/rules/#pyupgrade-up

% `ruff check --select=UP --statistics`
```
8	UP032	[*] f-string
2	UP008	[*] super-call-with-parameters
1	UP009	[*] utf8-encoding-declaration
1	UP028	[ ] yield-in-for-loop
1	UP031	[ ] printf-string-formatting
1	UP037	[*] quoted-annotation
Found 14 errors.
[*] 12 fixable with the `--fix` option (2 hidden fixes can be enabled with the `--unsafe-fixes` option).
```
% `ruff check --select=UP --fix --unsafe-fixes`