### PR TITLE
[ENG-9699] expiring timeseries indexes

### DIFF
--- a/.konchrc
+++ b/.konchrc
@@ -40,11 +40,11 @@ def setup():
     # Set up django and add the default elasticsearch-py client and Metric to the context
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "elasticsearch_metrics.tests.settings")
     django.setup()
-    from elasticsearch_metrics.imps.elastic8 import EventRecord, CyclicRecord
+    from elasticsearch_metrics.imps.elastic8 import EventRecord, CyclicReport
 
     context["client"] = elasticsearch8.dsl.connections.get_connection()
     context["EventRecord"] = EventRecord
-    context["CyclicRecord"] = CyclicRecord
+    context["CyclicReport"] = CyclicReport
     konch.config({"context": context})
 
 

--- a/README.md
+++ b/README.md
@@ -46,14 +46,13 @@ DJELME_BACKENDS = {
 
 In one of your apps, add record types in `metrics.py`
 
-
 ```python
 # myapp/metrics.py
 
 from elasticsearch_metrics.imps.elastic8 import EventRecord
 
 
-class UsageRecord(EventRecord):
+class UsageEvent(EventRecord):
     item_id: int
 
     class Index:
@@ -69,24 +68,24 @@ python manage.py djelme_backend_setup
 Now add some data:
 
 ```python
-from myapp.metrics import UsageRecord
+from myapp.metrics import UsageEvent
 
 # By default we create an index for each day.
 # Therefore, this will persist the document
 # to an index named for the record type and date
-UsageRecord.record(item_id='my.item.id')
+UsageEvent.record(item_id='my.item.id')
 ```
 
 Go forth and search!
 
 ```python
 # get an instance of `elasticsearch8.dsl.Search` that queries all timeseries indexes of this type:
-UsageRecord.search()
+UsageEvent.search()
 
 # or get a `Search` for a given time range (from_when <= timestamp < until_when)
-UsageRecord.search_timeseries_range((1999,), (2001,))  # in or after 1999; before 2001
-UsageRecord.search_timeseries_range((2050, 12), (2051,))  # in 2050-12
-UsageRecord.search_timeseries_range(datetime.date(2030, 1, 1), datetime.date(2030, 2, 1))  # in 2030-01
+UsageEvent.search_timeseries_range((1999,), (2001,))  # in or after 1999; before 2001
+UsageEvent.search_timeseries_range((2050, 12), (2051,))  # in 2050-12
+UsageEvent.search_timeseries_range(datetime.date(2030, 1, 1), datetime.date(2030, 2, 1))  # in 2030-01
 ```
 
 ## Timeseries indexes
@@ -113,7 +112,7 @@ You can configure the index settings that will be set on the index template
 and used for each new timeseries index with `Index.settings` on a record type.
 
 ```python
-class UsageRecord(EventRecord):
+class UsageEvent(EventRecord):
     item_id: int
 
     class Index:
@@ -124,7 +123,7 @@ class UsageRecord(EventRecord):
 
 Each record type will have its own [index template](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html).
 The index template name and glob pattern are computed from the app label
-for the containing app and the class's name. For example, a `UsageRecord`
+for the containing app and the class's name. For example, a `UsageEvent`
 class defined in `myapp/metrics.py` will have an index template with the
 name `myapp_usagerecord` and a template glob pattern of `myapp_usagerecord_*`.
 
@@ -132,7 +131,7 @@ If you declare a record type outside of an app, you will need to set `app_label`
 
 
 ```python
-class UsageRecord(EventRecord):
+class UsageEvent(EventRecord):
     class Meta:
         app_label = "myapp"
 ```
@@ -140,7 +139,7 @@ class UsageRecord(EventRecord):
 Alternatively, you can set `template_name` and/or `template` explicitly.
 
 ```python
-class UsageRecord(EventRecord):
+class UsageEvent(EventRecord):
     item_id: int
 
     class Meta:
@@ -161,7 +160,7 @@ class MyBaseMetric(EventRecord):
         abstract = True
 
 
-class UsageRecord(MyBaseMetric):
+class UsageEvent(MyBaseMetric):
     class Meta:
         app_label = "myapp"
 ```
@@ -200,11 +199,12 @@ class UsageRecord(MyBaseMetric):
 * `djelme_backend_setup`: Ensure that index templates have been created for your record types.
 * `djelme_backend_check`: Check if index templates are in sync. Exits
     with an error code if any templates are out of sync.
+* `djelme_indexes`: Inspect existing indexes and (with` --delete-expired`) delete expired indexes
 
 <!-- * `clean_metrics` : Clean old data using [curator](https://curator.readthedocs.io/en/latest/). -->
 <!--  -->
 <!-- ``` -->
-<!-- python manage.py clean_metrics myapp.UsageRecord --older-than 45 --time-unit days -->
+<!-- python manage.py clean_metrics myapp.UsageEvent --older-than 45 --time-unit days -->
 <!-- ``` -->
 
 ## Signals
@@ -219,20 +219,6 @@ Signals are located in the `elasticsearch_metrics.signals` module.
     Metric's `save()` method.
 * `post_save(Metric, instance, using, index)`: Sent at the end of a
     Metric's `save()` method.
-
-## Caveats
-
-* `_source` is disabled by default on metric indices in order to save
-    disk space. For most metrics use cases, Users will not need to retrieve the source
-    JSON documents. Be sure to understand the consequences of
-    this: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html#_disabling_source .
-    To enable `_source`, you can override it in `class Meta`.
-
-```python
-class MyMetric(EventRecord):
-    class Meta:
-        source = metrics.MetaField(enabled=True)
-```
 
 ## Resources
 

--- a/elasticsearch_metrics/imps/elastic8.py
+++ b/elasticsearch_metrics/imps/elastic8.py
@@ -14,12 +14,13 @@
 __all__ = (
     "EventRecord",
     "CountedUsageRecord",
-    "CyclicRecord",
+    "CyclicReport",
     # for ProtoDjelmeImp:
     "djelme_backend",
     "djelme_when_ready",
 )
-import collections
+from collections import ChainMap
+import collections.abc as cabc
 import dataclasses
 import datetime
 import functools
@@ -41,9 +42,20 @@ from elasticsearch_metrics.protocols import (
     ProtoCountedUsage,
     ProtoDjelmeRecord,
 )
-from elasticsearch_metrics.util import timeseries_naming
+from elasticsearch_metrics.util.timeseries_naming import (
+    TimeseriesIndexNaming,
+    TimeseriesRangePattern,
+    format_template_name,
+)
 from elasticsearch_metrics.util.django import find_app_label_for_module
-from elasticsearch_metrics.util.timeparts import format_full_timeparts, format_timeparts
+from elasticsearch_metrics.util.index_status import DjelmeIndexStatus
+from elasticsearch_metrics.util.timeparts import (
+    serialize_timeparts,
+    TimepartStrat,
+    GregorianTime,
+    Timeparts,
+    AbstractTimeparts,
+)
 from elasticsearch_metrics.util.anon_enough import opaque_key, opaque_sessionhour_id
 
 logger = logging.getLogger(__name__)
@@ -130,10 +142,10 @@ class _DjelmeRecordMetaclass(IndexMeta):
         and Index.settings, Index.analyzers, and Index.using are inherited
         (but not Index.name or Index.aliases)
         """
-        _base_index_configs = collections.ChainMap(
+        _base_index_configs = ChainMap(
             *(base._index.to_dict() for base in bases if hasattr(base, "_index"))
         )
-        _index_opts = opts or type("Index", (), {})
+        _index_opts: typing.Any = opts or type("Index", (), {})
         if not hasattr(_index_opts, "settings") and (
             _inherited_settings := _base_index_configs.get("settings")
         ):
@@ -191,7 +203,7 @@ class BaseDjelmeRecord(esdsl.Document, metaclass=_DjelmeRecordMetaclass):
     'elasticsearch_metrics'
     """
 
-    UNIQUE_TOGETHER_FIELDS: typing.ClassVar[collections.abc.Iterable[str]] = ()
+    UNIQUE_TOGETHER_FIELDS: typing.ClassVar[cabc.Iterable[str]] = ()
 
     class Meta:
         abstract = True
@@ -239,6 +251,12 @@ class BaseDjelmeRecord(esdsl.Document, metaclass=_DjelmeRecordMetaclass):
         )
         assert isinstance(_name_prefix, str)
         return _name_prefix
+
+    @classmethod
+    def each_existing_index(
+        cls, using: str | Elastic8Client | None = None
+    ) -> cabc.Iterator[DjelmeIndexStatus]:
+        raise NotImplementedError
 
     @classmethod
     def _get_djelme_backend(cls) -> "DjelmeElastic8Backend":
@@ -316,7 +334,7 @@ class BaseDjelmeRecord(esdsl.Document, metaclass=_DjelmeRecordMetaclass):
             # make it unique by setting doc id in elasticsearch
             self.meta.id = opaque_key(_unique_together)
 
-    def _get_unique_together_values(self) -> list:
+    def _get_unique_together_values(self) -> list[typing.Any]:
         return [
             getattr(self, _field_name)
             for _field_name in (self.UNIQUE_TOGETHER_FIELDS or ())
@@ -395,6 +413,20 @@ class SimpleRecord(BaseDjelmeRecord, metaclass=_SimpleRecordMetaclass):
         cls._index.delete(using=es_client, ignore_unavailable=True)
 
     @classmethod
+    def each_existing_index(
+        cls, using: str | Elastic8Client | None = None
+    ) -> cabc.Iterator[DjelmeIndexStatus]:
+        """yield existing index name, if any
+
+        implement BaseDjelmeRecord.each_existing_index
+        """
+        _resp = cls._get_connection(using).indices.get(
+            index=cls.djelme_index_name(), features=",", ignore_unavailable=True
+        )
+        for _index_name in _resp.keys():
+            yield DjelmeIndexStatus(_index_name)
+
+    @classmethod
     def refresh(cls, using: str | None = None) -> None:
         assert not cls.is_abstract
         cls._index.refresh(using=using)
@@ -433,7 +465,7 @@ class TimeseriesRecord(BaseDjelmeRecord):
         assert not cls.is_abstract
         return super().search(
             using=using,
-            index=(index or cls.format_timeseries_index_pattern()),
+            index=(index or cls.timeseries_index_wildcard()),
         )
 
     @classmethod
@@ -442,13 +474,19 @@ class TimeseriesRecord(BaseDjelmeRecord):
         from_when: tuple[int, ...] | datetime.date,
         until_when: tuple[int, ...] | datetime.date,
     ) -> typing.Any:
-        _index_pattern = cls.format_timeseries_index_pattern_for_range(
-            from_when, until_when
-        )
+        _index_pattern = cls.timeseries_index_range_pattern(from_when, until_when)
         _timeseries_q = esdsl.query.Range(
             timeseries_timeparts={
-                "gte": format_full_timeparts(from_when),
-                "lt": format_full_timeparts(until_when),
+                "gte": serialize_timeparts(
+                    cls.get_timepart_strat().get_timeparts(
+                        from_when, pad=False, truncate=False
+                    )
+                ),
+                "lt": serialize_timeparts(
+                    cls.get_timepart_strat().get_timeparts(
+                        until_when, pad=False, truncate=False
+                    )
+                ),
             }
         )
         return cls.search(index=_index_pattern).filter(_timeseries_q)
@@ -457,20 +495,34 @@ class TimeseriesRecord(BaseDjelmeRecord):
     def refresh(cls, using: str | None = None) -> None:
         assert not cls.is_abstract
         cls._get_connection(using).indices.refresh(
-            index=cls.format_timeseries_index_pattern()
+            index=cls.timeseries_index_wildcard()
         )
 
     @classmethod
-    def each_timeseries_index(
-        cls, using: str | None = None
-    ) -> collections.abc.Iterator[tuple[str, dict[str, typing.Any]]]:
+    def each_existing_index(
+        cls, using: str | Elastic8Client | None = None
+    ) -> cabc.Iterator[DjelmeIndexStatus]:
+        """yield status for each existing index
+
+        implement BaseDjelmeRecord.each_existing_index
+        """
         _resp = cls._get_connection(using).indices.get(
-            index=cls.format_timeseries_index_pattern(),
+            index=cls.timeseries_index_wildcard(),
         )
-        for _index_name, _index_info in _resp.items():
-            assert isinstance(_index_name, str)
-            assert isinstance(_index_info, dict)
-            yield _index_name, _index_info
+        _expired_if_before = (
+            cls.get_timepart_strat().get_timeparts(utcnow() - _expiration_delta)
+            if (_expiration_delta := cls.get_timeseries_index_expiration()) is not None
+            else None
+        )
+        for _index_name in sorted(_resp.keys()):
+            if _expired_if_before is None:
+                _is_expired = False
+            else:
+                _parsed = cls.parse_timeseries_index_name(_index_name)
+                _is_expired = bool(
+                    _parsed.timeparts and (_parsed.timeparts < _expired_if_before)
+                )
+            yield DjelmeIndexStatus(_index_name, _is_expired)
 
     @classmethod
     def do_teardown(
@@ -481,10 +533,8 @@ class TimeseriesRecord(BaseDjelmeRecord):
     ) -> None:
         assert not cls.is_abstract
         _client = cls._get_connection(using)
-        _indexname_wildcard = cls.format_timeseries_index_pattern()
-        _indices = _client.indices.get(index=_indexname_wildcard, features=",")
-        for _index_name in _indices.keys():
-            _client.indices.delete(index=_index_name)
+        for _index_status in cls.each_existing_index(using=_client):
+            cls.delete_index(_index_status.index_name, using=_client)
         if not keep_templates:
             _templatename = cls.get_timeseries_template_name()
             try:
@@ -497,12 +547,12 @@ class TimeseriesRecord(BaseDjelmeRecord):
         assert not cls.is_abstract
         return cls._index.as_composable_template(
             template_name=cls.get_timeseries_template_name(),
-            pattern=cls.format_timeseries_index_pattern(),
+            pattern=cls.timeseries_index_wildcard(),
         )
 
     @classmethod
     def get_timeseries_template_name(cls) -> str:
-        _template_name = timeseries_naming.format_template_name(
+        _template_name = format_template_name(
             cls.app_label, cls.get_timeseries_recordtype_name()
         )
         return "".join((cls.get_index_name_prefix(), _template_name))
@@ -516,29 +566,53 @@ class TimeseriesRecord(BaseDjelmeRecord):
         return _recordtype_name
 
     @classmethod
-    def format_timeseries_index_pattern(cls, timeparts: tuple[int, ...] = ()) -> str:
-        _pattern = timeseries_naming.format_index_pattern(
-            app_label=cls.app_label,
-            recordtype=cls.get_timeseries_recordtype_name(),
-            timeparts=timeparts,
-            max_timedepth=cls.get_timeseries_index_timedepth(),
+    def timeseries_index_naming(
+        cls, timeparts: AbstractTimeparts | datetime.date | str
+    ) -> TimeseriesIndexNaming:
+        return TimeseriesIndexNaming(
+            cls.app_label,
+            cls.get_timeseries_recordtype_name(),
+            timeparts,
+            cls.get_timepart_strat(),
+            prefix=cls.get_index_name_prefix(),
         )
-        return "".join((cls.get_index_name_prefix(), _pattern))
 
     @classmethod
-    def format_timeseries_index_pattern_for_range(
+    def parse_timeseries_index_name(cls, index_name: str) -> TimeseriesIndexNaming:
+        _parsed = TimeseriesIndexNaming.parse(
+            index_name,
+            timepart_strat=cls.get_timepart_strat(),
+            prefix=cls.get_index_name_prefix(),
+        )
+        if (
+            _parsed.app_label.lower() != cls.app_label.lower()
+            or _parsed.recordtype.lower()
+            != cls.get_timeseries_recordtype_name().lower()
+        ):
+            raise ValueError(f"index {index_name!r} does not belong to {cls}")
+        return _parsed
+
+    @classmethod
+    def timeseries_index_wildcard(cls, timeparts: tuple[int, ...] = ()) -> str:
+        _naming = cls.timeseries_index_naming(timeparts)
+        return _naming.to_str(wildcard=True)
+
+    @classmethod
+    def timeseries_index_range_pattern(
         cls,
         from_when: tuple[int, ...] | datetime.date,
         until_when: tuple[int, ...] | datetime.date | None,
     ) -> str:
-        _pattern = timeseries_naming.format_index_pattern_for_range(
-            cls.app_label,
-            cls.get_timeseries_recordtype_name(),
-            from_when,
-            until_when or utcnow(),
-            timedepth=cls.get_timeseries_index_timedepth(),
+        return str(
+            TimeseriesRangePattern(
+                cls.app_label,
+                cls.get_timeseries_recordtype_name(),
+                from_when,
+                until_when or utcnow(),
+                cls.get_timepart_strat(),
+                index_name_prefix=cls.get_index_name_prefix(),
+            )
         )
-        return "".join((cls.get_index_name_prefix(), _pattern))
 
     @classmethod
     def get_timeseries_index_timedepth(cls) -> int:
@@ -552,12 +626,16 @@ class TimeseriesRecord(BaseDjelmeRecord):
         return _timedepth
 
     @classmethod
+    def get_timepart_strat(cls) -> TimepartStrat:
+        return GregorianTime(cls.get_timeseries_index_timedepth())
+
+    @classmethod
     def _default_index(cls, index=None):
         """Overrides Document._default_index so that .search, .get, etc.
         use the metric's template pattern as the default index
         """
         assert not cls.is_abstract
-        return index or cls.format_timeseries_index_pattern()
+        return index or cls.timeseries_index_wildcard()
 
     @classmethod
     def sync_index_template(cls, using=None):  # -> ComposableIndexTemplate:
@@ -630,11 +708,29 @@ class TimeseriesRecord(BaseDjelmeRecord):
                     settings_in_sync=settings_in_sync,
                 )
 
+    @classmethod
+    def get_timeseries_index_expiration(cls) -> datetime.timedelta | None:
+        _val = cls._get_meta_attr("timeseries_index_expiration")
+        if not (_val is None or isinstance(_val, datetime.timedelta)):
+            raise ImproperlyConfigured(
+                "timeseries_index_expiration must be a timedelta", _val
+            )
+        return _val
+
+    @classmethod
+    def delete_index(
+        cls,
+        index_name: str,
+        using: str | Elastic8Client | None = None,
+    ) -> None:
+        _client = cls._get_connection(using)
+        _client.indices.delete(index=index_name)
+
     ###
     # instance methods
 
-    def get_timeseries_timeparts(self) -> str:
-        """semverlike string of timeparts, used to choose a timeseries index"""
+    def get_timeseries_timeparts(self) -> Timeparts:
+        """semverlike string of timeparts, used to choose a timeseries index and for range queries"""
         raise NotImplementedError(
             f"{self.__class__!r} must implement get_timeseries_timeparts"
         )
@@ -644,13 +740,7 @@ class TimeseriesRecord(BaseDjelmeRecord):
 
         for ProtoDjelmeRecord
         """
-        _index_name = timeseries_naming.format_index_name(
-            app_label=self.__class__.app_label,
-            recordtype=self.get_timeseries_recordtype_name(),
-            timeparts=self.timeseries_timeparts or self.get_timeseries_timeparts(),
-            max_timedepth=self.get_timeseries_index_timedepth(),
-        )
-        return "".join((self.get_index_name_prefix(), _index_name))
+        return str(self.timeseries_index_naming(self.get_timeseries_timeparts()))
 
     def clean(self) -> None:
         """save the record to a timeseries index
@@ -658,10 +748,9 @@ class TimeseriesRecord(BaseDjelmeRecord):
         extend `elasticsearch8.dsl.Document.save` to choose a specific timeseries index
         """
         super().clean()
-        self.timeseries_timeparts = self.get_timeseries_timeparts()
+        self.timeseries_timeparts = serialize_timeparts(self.get_timeseries_timeparts())
 
 
-# TODO: EventRecord expiration
 # class EventRecord(TimeseriesRecord, ProtoExpirableRecord?):
 class EventRecord(TimeseriesRecord):
     timestamp: datetime.datetime = esdsl.mapped_field(default_factory=lambda: utcnow())
@@ -669,12 +758,12 @@ class EventRecord(TimeseriesRecord):
     class Meta:
         abstract = True
 
-    def get_timeseries_timeparts(self) -> str:
-        """semverlike string of timeparts, used to choose a timeseries index
+    def get_timeseries_timeparts(self) -> Timeparts:
+        """semverlike string of timeparts, used to choose a timeseries index and for range queries
 
         for TimeseriesRecord
         """
-        return format_full_timeparts(self.timestamp)
+        return self.get_timepart_strat().get_timeparts(self.timestamp, truncate=False)
 
 
 # class CountedUsageRecord(EventRecord, ProtoCountedUsage):
@@ -722,12 +811,10 @@ class CountedUsageRecord(EventRecord):
         return _new_record
 
 
-class CyclicRecord(TimeseriesRecord):
-    """CyclicRecord: for recording something on a regular cycle"""
+class CyclicReport(TimeseriesRecord):
+    """CyclicReport: for recording something on a regular cycle"""
 
-    UNIQUE_TOGETHER_FIELDS: typing.ClassVar[collections.abc.Iterable[str]] = (
-        "cycle_coverage",
-    )
+    UNIQUE_TOGETHER_FIELDS: typing.ClassVar[cabc.Iterable[str]] = ("cycle_coverage",)
 
     CYCLE_TIMEDEPTH: typing.ClassVar[int]  # required on subclasses
 
@@ -737,7 +824,7 @@ class CyclicRecord(TimeseriesRecord):
     class Meta:
         abstract = True
 
-    def __init_subclass__(cls, **kwargs) -> None:
+    def __init_subclass__(cls, **kwargs: typing.Any) -> None:
         super().__init_subclass__(**kwargs)
         if not cls.is_abstract:
             _cycle_timedepth = getattr(cls, "CYCLE_TIMEDEPTH", None)
@@ -747,24 +834,36 @@ class CyclicRecord(TimeseriesRecord):
                 )
             if "cycle_coverage" not in cls.UNIQUE_TOGETHER_FIELDS:
                 raise ImproperlyConfigured(
-                    f'CyclicRecord subclasses must have "cycle_coverage" in UNIQUE_TOGETHER_FIELDS ({cls!r})'
+                    f'CyclicReport subclasses must have "cycle_coverage" in UNIQUE_TOGETHER_FIELDS ({cls!r})'
                 )
 
-    def get_timeseries_timeparts(self) -> str:
-        """semverlike string of timeparts, used to choose a timeseries index
+    @classmethod
+    def get_cycle_timepart_strat(cls) -> TimepartStrat:
+        return GregorianTime(cls.CYCLE_TIMEDEPTH)
+
+    def clean(self) -> None:
+        self.cycle_coverage = serialize_timeparts(
+            self.get_cycle_timepart_strat().get_timeparts(self.cycle_coverage)
+        )
+        super().clean()
+
+    def get_timeseries_timeparts(self) -> Timeparts:
+        """semverlike string of timeparts, used to choose a timeseries index and for range queries
 
         for TimeseriesRecord
 
-        use `cycle_coverage`; index by the start of the covered timespan
+        mirror `cycle_coverage`; index by the start of the covered timespan
         """
-        return format_timeparts(self.cycle_coverage, self.CYCLE_TIMEDEPTH)
+        return self.get_timepart_strat().get_timeparts(
+            self.cycle_coverage, truncate=False, pad=False
+        )
 
 
 @dataclasses.dataclass
 class DjelmeElastic8Backend:
     """DjelmeElastic8Backend: elastic8 backend for djelme (for use by generic djelme code)"""
 
-    _NON_PASSTHRU_KWARGS: typing.ClassVar[collections.abc.Collection[str]] = {
+    _NON_PASSTHRU_KWARGS: typing.ClassVar[cabc.Collection[str]] = {
         "djelme_default_index_name_prefix",
     }
 
@@ -798,14 +897,14 @@ class DjelmeElastic8Backend:
             if _key not in self._NON_PASSTHRU_KWARGS
         }
 
-    def djelme_setup(self, recordtypes: collections.abc.Iterable[type]) -> None:
+    def djelme_setup(self, recordtypes: cabc.Iterable[type]) -> None:
         # for ProtoDjelmeBackend
         for _recordtype in recordtypes:
             # TODO: logger.info
             assert issubclass(_recordtype, BaseDjelmeRecord)
             _recordtype.init(using=self._elastic8dsl_connection_name)
 
-    def djelme_teardown(self, recordtypes: collections.abc.Iterable[type]) -> None:
+    def djelme_teardown(self, recordtypes: cabc.Iterable[type]) -> None:
         # for ProtoDjelmeBackend
         for _recordtype in recordtypes:
             assert issubclass(_recordtype, BaseDjelmeRecord)
@@ -825,7 +924,7 @@ djelme_backend = DjelmeElastic8Backend  # for ProtoDjelmeImp
 
 
 def djelme_when_ready(  # for ProtoDjelmeImp
-    backends: collections.abc.Iterable[ProtoDjelmeBackend],
+    backends: cabc.Iterable[ProtoDjelmeBackend],
 ) -> None:
     esdsl.connections.configure(
         **{

--- a/elasticsearch_metrics/management/commands/djelme_backend_check.py
+++ b/elasticsearch_metrics/management/commands/djelme_backend_check.py
@@ -12,7 +12,9 @@ class Command(BaseCommand):
     help = "Check if registered recordtypes have a corresponding index templates in Elasticsearch."
 
     def add_arguments(self, parser):
-        parser.add_argument("app_label", nargs="?", help="App label of an application.")
+        parser.add_argument(
+            "app_label", nargs="?", help="App label of a django application."
+        )
 
     def handle(self, *args, **options):
         # Avoid elasticsearch requests from getting logged
@@ -23,7 +25,6 @@ class Command(BaseCommand):
             if options["app_label"]
             else list(djelme_registry.each_app_label())
         )
-
         out_of_sync_count = 0
         self.stdout.write("Checking for outdated index templates...")
         for _app_label in _app_labels:
@@ -36,11 +37,11 @@ class Command(BaseCommand):
 
         if out_of_sync_count:
             self.stdout.write(
-                "{} index template(s) not set up.".format(out_of_sync_count),
+                f"{out_of_sync_count} index template(s) not set up.",
                 style.ERROR,
             )
             cmd = colorize("python manage.py djelme_backend_setup", opts=("bold",))
-            self.stdout.write("Run {cmd} to set up index templates.".format(cmd=cmd))
+            self.stdout.write(f"Run {cmd} to set up index templates.")
             raise CommandError(1)
         else:
             self.stdout.write("All djelme recordtypes set up.", style.SUCCESS)

--- a/elasticsearch_metrics/management/commands/djelme_backend_setup.py
+++ b/elasticsearch_metrics/management/commands/djelme_backend_setup.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from elasticsearch_metrics.registry import djelme_registry
 from elasticsearch_metrics.management.color import color_style
@@ -9,9 +9,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "app_label",
-            nargs="?",
-            help="App label of an application to synchronize the state.",
+            "app_label", nargs="?", help="App label of a django application."
         )
 
     def handle(self, *args, **options):
@@ -25,17 +23,14 @@ class Command(BaseCommand):
         )
         for _app_label in _app_labels:
             self.stdout.write(
-                "Syncing recordtypes for app: '{}'".format(_app_label),
+                f"Syncing recordtypes for app: {_app_label}",
                 style.MIGRATE_HEADING,
             )
-            try:
-                _types_by_backend = djelme_registry.recordtypes_by_backend(
-                    app_label=_app_label
-                )
-            except LookupError as _err:
-                raise CommandError(
-                    f"No recordtypes found for app {_app_label!r}"
-                ) from _err
+            _types_by_backend = djelme_registry.recordtypes_by_backend(
+                app_label=_app_label
+            )
+            if not _types_by_backend:
+                self.stdout.write(f"No recordtypes found for app {_app_label!r}")
             for _backend_name, _each_recordtype in _types_by_backend.items():
                 _backend = djelme_registry.get_backend(_backend_name)
                 self.stdout.write(f"  Using backend {_backend_name!r}...")

--- a/elasticsearch_metrics/management/commands/djelme_backend_types.py
+++ b/elasticsearch_metrics/management/commands/djelme_backend_types.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from elasticsearch_metrics.registry import djelme_registry
 from elasticsearch_metrics.management.color import color_style
@@ -8,22 +8,19 @@ class Command(BaseCommand):
     help = "Pretty-print a listing of all registered djelme recordtypes."
 
     def add_arguments(self, parser):
-        parser.add_argument("app_label", nargs="?", help="App label of an application.")
+        parser.add_argument(
+            "app_label", nargs="?", help="App label of a django application."
+        )
 
     def handle(self, *args, **options):
         style = color_style()
-        if options["app_label"]:
-            if options["app_label"] not in djelme_registry.each_app_label():
-                raise CommandError(
-                    "No recordtypes found for app '{}'".format(options["app_label"])
-                )
-            app_labels = [options["app_label"]]
-        else:
-            app_labels = list(djelme_registry.each_app_label())
-        for app_label in app_labels:
-            self.stdout.write(
-                "Recordtypes for '{}':".format(app_label), style.MIGRATE_HEADING
-            )
+        _app_labels = (
+            [options["app_label"]]
+            if options["app_label"]
+            else list(djelme_registry.each_app_label())
+        )
+        for app_label in _app_labels:
+            self.stdout.write(f"Recordtypes for {app_label!r}", style.MIGRATE_HEADING)
             for _recordtype in djelme_registry.each_recordtype(app_label=app_label):
                 _recordtype_name = style.TYPENAME(_recordtype.__name__)
                 self.stdout.write(f"{app_label}.{_recordtype_name}")

--- a/elasticsearch_metrics/management/commands/djelme_indexes.py
+++ b/elasticsearch_metrics/management/commands/djelme_indexes.py
@@ -1,0 +1,69 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from elasticsearch_metrics.registry import djelme_registry
+from elasticsearch_metrics.protocols import ProtoDjelmeRecord
+
+
+class Command(BaseCommand):
+    help = "Inspect and manage existing indexes"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "app_label", nargs="?", help="App label of a django application."
+        )
+        parser.add_argument(
+            "--delete-expired",
+            action="store_true",
+            help="Delete indexes past their expiration date",
+        )
+        parser.add_argument(
+            "--really-really",
+            action="store_true",
+            help="Skip confirmation for --delete-expired",
+        )
+
+    def handle(self, *args, **options):
+        # Avoid elasticsearch requests from getting logged
+        logging.getLogger("elastic_transport").setLevel(logging.ERROR)
+        _app_labels = (
+            [options["app_label"]]
+            if options["app_label"]
+            else list(djelme_registry.each_app_label())
+        )
+        if options["delete_expired"]:
+            self._delete_expired_indexes(_app_labels, options["really_really"])
+        else:
+            self._list_existing_indexes(_app_labels)
+
+    def _list_existing_indexes(self, app_labels: list[str]) -> None:
+        self.stdout.write("Existing indexes:")
+        for _app_label in app_labels:
+            for _recordtype in djelme_registry.each_recordtype(app_label=_app_label):
+                for _index_status in _recordtype.each_existing_index():
+                    _suffix = " (expired)" if _index_status.is_expired else ""
+                    self.stdout.write(f"{_index_status.index_name}{_suffix}")
+
+    def _delete_expired_indexes(
+        self, app_labels: list[str], skip_confirmation: bool
+    ) -> None:
+        self.stdout.write("Expired indexes:")
+        _to_delete: list[tuple[type[ProtoDjelmeRecord], str]] = []
+        for _app_label in app_labels:
+            for _recordtype in djelme_registry.each_recordtype(app_label=_app_label):
+                for _index_status in _recordtype.each_existing_index():
+                    if _index_status.is_expired:
+                        _to_delete.append((_recordtype, _index_status.index_name))
+                        if not skip_confirmation:
+                            self.stdout.write(_index_status.index_name)
+        if not _to_delete:
+            self.stdout.write("No expired indexes.")
+            return
+        if not skip_confirmation:
+            _confirm_response = input("Really delete all these indexes? (y/N)")
+            if _confirm_response.lower() != "y":
+                return
+        for _recordtype, _index_name in _to_delete:
+            self.stdout.write(f"deleting {_index_name}")
+            _recordtype.delete_index(_index_name)

--- a/elasticsearch_metrics/protocols.py
+++ b/elasticsearch_metrics/protocols.py
@@ -3,6 +3,8 @@ import collections
 import datetime
 import typing
 
+from elasticsearch_metrics.util.index_status import DjelmeIndexStatus
+
 __all__ = (
     "ProtoDjelmeBackend",
     "ProtoDjelmeImp",
@@ -58,6 +60,11 @@ class ProtoDjelmeRecord(typing.Protocol):
         until_when: tuple[int, ...] | datetime.date,
         **kwargs: typing.Any,
     ) -> typing.Any: ...
+
+    @classmethod
+    def each_existing_index(
+        cls, using: str | None = None
+    ) -> collections.abc.Iterator[DjelmeIndexStatus]: ...
 
     # @classmethod
     # def each_timeseries_index_status(cls) -> collections.abc.Iterable[str]: ...

--- a/elasticsearch_metrics/registry.py
+++ b/elasticsearch_metrics/registry.py
@@ -79,12 +79,8 @@ class _DjelmeRegistry:
         if recordtype_name in app_recordtypes:
             # Raise an error for conflicting recordtype names (same behavior as apps.register_model)
             raise RuntimeError(
-                "Conflicting '{}' recordtypes in application '{}': {} and {}.".format(
-                    recordtype_name,
-                    _app_label,
-                    app_recordtypes[recordtype_name],
-                    recordtype,
-                )
+                f"Conflicting {recordtype_name!r} recordtypes in application {_app_label!r}: "
+                f"{app_recordtypes[recordtype_name]} and {recordtype}"
             )
         app_recordtypes[recordtype_name] = recordtype
         self._imp_by_recordtype[recordtype] = imp_module_name
@@ -117,9 +113,7 @@ class _DjelmeRegistry:
             return app_recordtypes[format_namepart(recordtype_name)]
         except KeyError as e:
             raise LookupError(
-                "App '{}' doesn't have a '{}' metric.".format(
-                    app_label, recordtype_name
-                )
+                f"App {app_label!r} doesn't have a {recordtype_name!r} metric."
             ) from e
 
     def get_recordtype_app_label(self, recordtype: type) -> str | None:
@@ -246,10 +240,8 @@ class _DjelmeRegistry:
         self, app_label: str
     ) -> collections.abc.Mapping[str, type]:
         if app_label not in self._all_recordtypes:
-            raise LookupError(
-                "No recordtypes found in app with label '{}'.".format(app_label)
-            )
-        return self._all_recordtypes[app_label]
+            apps.get_app_config(app_label)  # raise LookupError if invalid app
+        return self._all_recordtypes.get(app_label, {})
 
 
 def _import_imp_module(imp_module_name: str) -> ProtoDjelmeImp:

--- a/elasticsearch_metrics/tests/dummy8app/metrics.py
+++ b/elasticsearch_metrics/tests/dummy8app/metrics.py
@@ -1,3 +1,5 @@
+import datetime
+
 from elasticsearch8 import dsl as esdsl
 from elasticsearch_metrics.imps import elastic8 as djelme
 
@@ -33,10 +35,12 @@ class ThingHappened(djelme.EventRecord):
 
     class Meta:
         timeseries_recordtype_name = "happen"
-        timeseries_index_timedepth = 1  # yearly timeseries indexes
+        timeseries_index_timedepth = 2  # monthly timeseries indexes
+        # keep ninety days of data
+        timeseries_index_expiration = datetime.timedelta(days=90)
 
 
-class ThingHappeningsReport(djelme.CyclicRecord):
+class ThingHappeningsReport(djelme.CyclicReport):
     CYCLE_TIMEDEPTH = 2
     UNIQUE_TOGETHER_FIELDS = ("cycle_coverage", "thing_id")
 
@@ -45,7 +49,7 @@ class ThingHappeningsReport(djelme.CyclicRecord):
 
     class Meta:
         index_name_prefix = "blarg_"
-        timeseries_index_timedepth = 2  # monthly timeseries indexes
+        timeseries_index_timedepth = 1  # yearly timeseries indexes
 
 
 class SimpleKV(djelme.SimpleRecord):

--- a/elasticsearch_metrics/tests/test_imps_elastic8.py
+++ b/elasticsearch_metrics/tests/test_imps_elastic8.py
@@ -53,7 +53,7 @@ class TestNamesAndPatterns(SimpleDjelmeTestCase):
         _thingevent = ThingHappened(timestamp=_stamp, thing_id="hi")
         self.assertEqual(
             _thingevent.djelme_index_name(),
-            "dummy8app_happen_2020.",
+            "dummy8app_happen_2020.2.",
         )
         _thingreport = ThingHappeningsReport(
             timestamp=_stamp,
@@ -63,7 +63,7 @@ class TestNamesAndPatterns(SimpleDjelmeTestCase):
         )
         self.assertEqual(
             _thingreport.djelme_index_name(),
-            "blarg_dummy8app_thinghappeningsreport_1999.3.",
+            "blarg_dummy8app_thinghappeningsreport_1999.",
         )
         _kv = SimpleKV(key="wha", val=0)
         self.assertEqual(
@@ -89,7 +89,7 @@ class TestNamesAndPatterns(SimpleDjelmeTestCase):
             _thingevent = ThingHappened(timestamp=_stamp, thing_id="ha")
             self.assertEqual(
                 _thingevent.djelme_index_name(),
-                "dummy8app_happen_2020.",
+                "dummy8app_happen_2020.2.",
             )
             _thingreport = ThingHappeningsReport(
                 timestamp=_stamp,
@@ -99,80 +99,99 @@ class TestNamesAndPatterns(SimpleDjelmeTestCase):
             )
             self.assertEqual(
                 _thingreport.djelme_index_name(),
-                "blarg_dummy8app_thinghappeningsreport_1999.3.",
+                "blarg_dummy8app_thinghappeningsreport_1999.",
             )
 
     def test_format_timeseries_index_pattern__lotsa_parts(self):
         _timeparts = (2020, 2, 14, 0, 1, 2)
         self.assertEqual(
-            Dummy8Event.format_timeseries_index_pattern(_timeparts),
+            Dummy8Event.timeseries_index_wildcard(_timeparts),
             "dummy8app_dummy8event_2020.2.14.*",
         )
         self.assertEqual(
-            Monthly8Event.format_timeseries_index_pattern(_timeparts),
+            Monthly8Event.timeseries_index_wildcard(_timeparts),
             "dummy8evenzdummy8app_eventlog_2020.2.*",
         )
         self.assertEqual(
-            ThingHappened.format_timeseries_index_pattern(_timeparts),
-            "dummy8app_happen_2020.*",
+            ThingHappened.timeseries_index_wildcard(_timeparts),
+            "dummy8app_happen_2020.2.*",
         )
         self.assertEqual(
-            ThingHappeningsReport.format_timeseries_index_pattern(_timeparts),
-            "blarg_dummy8app_thinghappeningsreport_2020.2.*",
+            ThingHappeningsReport.timeseries_index_wildcard(_timeparts),
+            "blarg_dummy8app_thinghappeningsreport_2020.*",
         )
 
     def test_format_timeseries_index_pattern__some_parts(self):
         _timeparts = (2020, 2, 14)
         self.assertEqual(
-            Dummy8Event.format_timeseries_index_pattern(_timeparts),
+            Dummy8Event.timeseries_index_wildcard(_timeparts),
             "dummy8app_dummy8event_2020.2.14.*",
         )
         self.assertEqual(
-            Monthly8Event.format_timeseries_index_pattern(_timeparts),
+            Monthly8Event.timeseries_index_wildcard(_timeparts),
             "dummy8evenzdummy8app_eventlog_2020.2.*",
         )
         self.assertEqual(
-            ThingHappened.format_timeseries_index_pattern(_timeparts),
-            "dummy8app_happen_2020.*",
+            ThingHappened.timeseries_index_wildcard(_timeparts),
+            "dummy8app_happen_2020.2.*",
         )
         self.assertEqual(
-            ThingHappeningsReport.format_timeseries_index_pattern(_timeparts),
-            "blarg_dummy8app_thinghappeningsreport_2020.2.*",
+            ThingHappeningsReport.timeseries_index_wildcard(_timeparts),
+            "blarg_dummy8app_thinghappeningsreport_2020.*",
         )
 
     def test_format_timeseries_index_pattern__one_part(self):
         _timeparts = (2020,)
         self.assertEqual(
-            Dummy8Event.format_timeseries_index_pattern(_timeparts),
+            Dummy8Event.timeseries_index_wildcard(_timeparts),
             "dummy8app_dummy8event_2020.*",
         )
         self.assertEqual(
-            Monthly8Event.format_timeseries_index_pattern(_timeparts),
+            Monthly8Event.timeseries_index_wildcard(_timeparts),
             "dummy8evenzdummy8app_eventlog_2020.*",
         )
         self.assertEqual(
-            ThingHappened.format_timeseries_index_pattern(_timeparts),
+            ThingHappened.timeseries_index_wildcard(_timeparts),
             "dummy8app_happen_2020.*",
         )
         self.assertEqual(
-            ThingHappeningsReport.format_timeseries_index_pattern(_timeparts),
+            ThingHappeningsReport.timeseries_index_wildcard(_timeparts),
             "blarg_dummy8app_thinghappeningsreport_2020.*",
+        )
+
+    def test_format_timeseries_index_pattern__no_parts(self):
+        _timeparts = ()
+        self.assertEqual(
+            Dummy8Event.timeseries_index_wildcard(_timeparts),
+            "dummy8app_dummy8event_*",
+        )
+        self.assertEqual(
+            Monthly8Event.timeseries_index_wildcard(_timeparts),
+            "dummy8evenzdummy8app_eventlog_*",
+        )
+        self.assertEqual(
+            ThingHappened.timeseries_index_wildcard(_timeparts),
+            "dummy8app_happen_*",
+        )
+        self.assertEqual(
+            ThingHappeningsReport.timeseries_index_wildcard(_timeparts),
+            "blarg_dummy8app_thinghappeningsreport_*",
         )
 
     def test_format_index_pattern_respects_date_format_setting(self):
         with self.settings(DJELME_DEFAULT_TIMEDEPTH=4):
             _timeparts = (2020, 2, 14, 0, 1, 2)
             self.assertEqual(
-                Dummy8Event.format_timeseries_index_pattern(_timeparts),
+                Dummy8Event.timeseries_index_wildcard(_timeparts),
                 "dummy8app_dummy8event_2020.2.14.0.*",
             )
             self.assertEqual(
-                Monthly8Event.format_timeseries_index_pattern(_timeparts),
+                Monthly8Event.timeseries_index_wildcard(_timeparts),
                 "dummy8evenzdummy8app_eventlog_2020.2.*",
             )
             self.assertEqual(
-                ThingHappened.format_timeseries_index_pattern(_timeparts),
-                "dummy8app_happen_2020.*",
+                ThingHappened.timeseries_index_wildcard(_timeparts),
+                "dummy8app_happen_2020.2.*",
             )
 
 
@@ -393,7 +412,7 @@ class TestWithoutAutosetup(NoSetupRealElasticTestCase):
     def test_cannot_save_with_wrong_template_pattern(self):
         with mock.patch.object(
             Dummy8Event,
-            "format_timeseries_index_pattern",
+            "timeseries_index_wildcard",
             return_value="wrong_pattern_haha_*",
         ):
             Dummy8Event.init()
@@ -426,7 +445,7 @@ class TestWithoutAutosetup(NoSetupRealElasticTestCase):
         ThingHappened.init()
         _client = _es8_client()
         _template_name = ThingHappened.get_timeseries_template_name()
-        _index_pattern = ThingHappened.format_timeseries_index_pattern()
+        _index_pattern = ThingHappened.timeseries_index_wildcard()
         _template_resp = _client.indices.get_index_template(name=_template_name)
         (_t_info,) = _template_resp["index_templates"]
         self.assertEqual(_t_info["name"], _template_name)
@@ -439,7 +458,7 @@ class TestWithoutAutosetup(NoSetupRealElasticTestCase):
         self.assertEqual(_properties["thing_id"], {"type": "keyword"})
         self.assertEqual(_properties["happen_code"], {"type": "keyword"})
         # no indexes; only the template
-        self.assertFalse(list(ThingHappened.each_timeseries_index()))
+        self.assertFalse(list(ThingHappened.each_existing_index()))
 
     def test_check_djelme_setup(self):
         with self.assertRaises(IndexTemplateNotFoundError):
@@ -476,8 +495,8 @@ class TestDailyIndexes(RealElasticTestCase):
 
     def test_indexes(self):
         _index_names = {
-            _strip_test_prefix(_name)
-            for _name, _ in Dummy8Event.each_timeseries_index()
+            _strip_test_prefix(_index_status.index_name)
+            for _index_status in Dummy8Event.each_existing_index()
         }
         self.assertEqual(
             _index_names,
@@ -538,8 +557,8 @@ class TestMonthlyIndexes(RealElasticTestCase):
 
     def test_indexes(self):
         _index_names = {
-            _strip_test_prefix(_name)
-            for _name, _ in Monthly8Event.each_timeseries_index()
+            _strip_test_prefix(_index_status.index_name)
+            for _index_status in Monthly8Event.each_existing_index()
         }
         self.assertEqual(
             _index_names,
@@ -599,15 +618,17 @@ class TestYearlyIndexes(RealElasticTestCase):
 
     def test_indexes(self):
         _index_names = {
-            _strip_test_prefix(_name)
-            for _name, _ in ThingHappened.each_timeseries_index()
+            _strip_test_prefix(_index_status.index_name)
+            for _index_status in ThingHappened.each_existing_index()
         }
         self.assertEqual(
             _index_names,
             {
-                "dummy8app_happen_1234.",
-                "dummy8app_happen_1235.",
-                "dummy8app_happen_2345.",
+                "dummy8app_happen_1234.5.",
+                "dummy8app_happen_1234.6.",
+                "dummy8app_happen_1235.5.",
+                "dummy8app_happen_2345.6.",
+                "dummy8app_happen_2345.7.",
             },
         )
 
@@ -644,7 +665,7 @@ class TestYearlyIndexes(RealElasticTestCase):
         )
 
 
-class TestCyclicRecord(RealElasticTestCase):
+class TestCyclicReport(RealElasticTestCase):
     def setUp(self):
         super().setUp()
         ThingHappeningsReport.record(
@@ -672,14 +693,13 @@ class TestCyclicRecord(RealElasticTestCase):
 
     def test_indexes(self):
         _index_names = {
-            _strip_test_prefix(_name)
-            for _name, _ in ThingHappeningsReport.each_timeseries_index()
+            _strip_test_prefix(_index_status.index_name)
+            for _index_status in ThingHappeningsReport.each_existing_index()
         }
         self.assertEqual(
             _index_names,
             {
-                "dummy8app_thinghappeningsreport_2000.1.",
-                "dummy8app_thinghappeningsreport_2000.2.",
+                "dummy8app_thinghappeningsreport_2000.",
             },
         )
 

--- a/elasticsearch_metrics/tests/test_management_commands/test_djelme_check.py
+++ b/elasticsearch_metrics/tests/test_management_commands/test_djelme_check.py
@@ -44,3 +44,7 @@ class TestCheckRecordtypes(SimpleDjelmeTestCase):
             + self.mock8_simple_check_djelme_setup.call_count
         )
         assert _call_count == len(list(registry.each_recordtype()))
+
+    def test_with_invalid_app(self):
+        with self.assertRaises(LookupError):
+            self.run_mgmt_command(djelme_backend_check, "notanapp")

--- a/elasticsearch_metrics/tests/test_management_commands/test_djelme_indexes.py
+++ b/elasticsearch_metrics/tests/test_management_commands/test_djelme_indexes.py
@@ -1,0 +1,104 @@
+import datetime
+from unittest import mock
+
+from elasticsearch_metrics.management.commands import djelme_indexes
+from elasticsearch_metrics.tests.util import MockConnectionTestCase
+
+
+class TestDjelmeIndexes(MockConnectionTestCase):
+    def setUp(self):
+        super().setUp()
+        self._fake_now = datetime.datetime(2016, 8, 21, tzinfo=datetime.timezone.utc)
+        self.enterContext(
+            mock.patch(
+                "elasticsearch_metrics.imps.elastic8.utcnow",
+                return_value=self._fake_now,
+            )
+        )
+        self.mock_es8_connection.indices.get.side_effect = self._fake_get_indexes
+
+    def _fake_get_indexes(self, *, index, **kwargs):
+        if index == "dummy8app_happen_*":
+            return {
+                "dummy8app_happen_1999.1.": {},
+                "dummy8app_happen_2015.1.": {},
+                "dummy8app_happen_2015.12.": {},
+                "dummy8app_happen_2016.1.": {},
+                "dummy8app_happen_2016.2.": {},
+                "dummy8app_happen_2016.3.": {},
+                "dummy8app_happen_2016.4.": {},
+                "dummy8app_happen_2016.5.": {},
+                "dummy8app_happen_2016.6.": {},
+                "dummy8app_happen_2016.7.": {},
+                "dummy8app_happen_2016.8.": {},
+            }
+        if index == "dummy8app_dummy8event_*":
+            return {
+                "dummy8app_dummy8event_1999.1.": {},
+                "dummy8app_dummy8event_2015.12.": {},
+                "dummy8app_dummy8event_2016.1.": {},
+                "dummy8app_dummy8event_2016.2.": {},
+                "dummy8app_dummy8event_2016.3.": {},
+                "dummy8app_dummy8event_2016.4.": {},
+                "dummy8app_dummy8event_2016.5.": {},
+                "dummy8app_dummy8event_2016.6.": {},
+                "dummy8app_dummy8event_2016.7.": {},
+                "dummy8app_dummy8event_2016.8.": {},
+            }
+        if index == "blarg_dummy8app_thinghappeningsreport_*":
+            return {
+                "dummy8app_thinghappeningsreport_1999.": {},
+                "dummy8app_thinghappeningsreport_2015.": {},
+                "dummy8app_thinghappeningsreport_2016.": {},
+            }
+        return {}
+
+    def test_without_args(self):
+        _out, _err = self.run_mgmt_command(djelme_indexes)
+        self.assertFalse(self.mock_es8_connection.indices.delete.called)
+        _outlines = _out.split("\n")
+        self.assertIn("dummy8app_happen_1999.1. (expired)", _outlines)
+        self.assertIn("dummy8app_happen_2015.1. (expired)", _outlines)
+        self.assertIn("dummy8app_happen_2015.12. (expired)", _outlines)
+        self.assertIn("dummy8app_happen_2016.1. (expired)", _outlines)
+        self.assertIn("dummy8app_happen_2016.2. (expired)", _outlines)
+        self.assertIn("dummy8app_happen_2016.3. (expired)", _outlines)
+        self.assertIn("dummy8app_happen_2016.4. (expired)", _outlines)
+        self.assertIn("dummy8app_happen_2016.5.", _outlines)
+        self.assertIn("dummy8app_happen_2016.6.", _outlines)
+        self.assertIn("dummy8app_happen_2016.7.", _outlines)
+        self.assertIn("dummy8app_happen_2016.8.", _outlines)
+        self.assertIn("dummy8app_dummy8event_1999.1.", _outlines)
+        self.assertIn("dummy8app_dummy8event_2015.12.", _outlines)
+        self.assertIn("dummy8app_dummy8event_2016.1.", _outlines)
+        self.assertIn("dummy8app_dummy8event_2016.2.", _outlines)
+        self.assertIn("dummy8app_dummy8event_2016.3.", _outlines)
+        self.assertIn("dummy8app_dummy8event_2016.4.", _outlines)
+        self.assertIn("dummy8app_dummy8event_2016.5.", _outlines)
+        self.assertIn("dummy8app_dummy8event_2016.6.", _outlines)
+        self.assertIn("dummy8app_dummy8event_2016.7.", _outlines)
+        self.assertIn("dummy8app_dummy8event_2016.8.", _outlines)
+        self.assertIn("dummy8app_thinghappeningsreport_1999.", _outlines)
+        self.assertIn("dummy8app_thinghappeningsreport_2015.", _outlines)
+        self.assertIn("dummy8app_thinghappeningsreport_2016.", _outlines)
+
+    def test_delete_expired_really(self):
+        out, err = self.run_mgmt_command(
+            djelme_indexes, "--delete-expired", "--really-really"
+        )
+        self.assertEqual(
+            self.mock_es8_connection.indices.delete.call_args_list,
+            [
+                mock.call(index="dummy8app_happen_1999.1."),
+                mock.call(index="dummy8app_happen_2015.1."),
+                mock.call(index="dummy8app_happen_2015.12."),
+                mock.call(index="dummy8app_happen_2016.1."),
+                mock.call(index="dummy8app_happen_2016.2."),
+                mock.call(index="dummy8app_happen_2016.3."),
+                mock.call(index="dummy8app_happen_2016.4."),
+            ],
+        )
+
+    def test_with_invalid_app(self):
+        with self.assertRaises(LookupError):
+            self.run_mgmt_command(djelme_indexes, "notanapp")

--- a/elasticsearch_metrics/tests/test_management_commands/test_djelme_setup.py
+++ b/elasticsearch_metrics/tests/test_management_commands/test_djelme_setup.py
@@ -1,7 +1,5 @@
 import unittest
 
-from django.core.management import CommandError
-
 from elasticsearch_metrics.imps import elastic8
 from elasticsearch_metrics.management.commands import djelme_backend_setup
 from elasticsearch_metrics.registry import djelme_registry
@@ -32,9 +30,8 @@ class TestDjelmeSetup(SimpleDjelmeTestCase):
         assert "Synchronized recordtypes." in out
 
     def test_with_invalid_app(self):
-        with self.assertRaises(CommandError) as _raises:
+        with self.assertRaises(LookupError):
             self.run_mgmt_command(djelme_backend_setup, "notanapp")
-        assert "No recordtypes found for app 'notanapp'" in str(_raises.exception)
 
     def test_with_app_label(self):
         class DummyMetric2(elastic8.SimpleRecord):

--- a/elasticsearch_metrics/tests/test_management_commands/test_djelme_types.py
+++ b/elasticsearch_metrics/tests/test_management_commands/test_djelme_types.py
@@ -3,7 +3,7 @@ from elasticsearch_metrics.tests.util import SimpleDjelmeTestCase
 
 
 class TestDjelmeTypesCommand(SimpleDjelmeTestCase):
-    def test_without_args_by_name(self):
+    def test_without_args(self):
         out, err = self.run_mgmt_command(djelme_backend_types)
         assert "Dummy8Event" in out
         assert "Monthly8Event" in out
@@ -11,10 +11,6 @@ class TestDjelmeTypesCommand(SimpleDjelmeTestCase):
         assert "ThingHappeningsReport" in out
         assert "SimpleKV" in out
 
-    def test_without_args_by_command(self):
-        out, err = self.run_mgmt_command("djelme_backend_types")
-        assert "Dummy8Event" in out
-        assert "Monthly8Event" in out
-        assert "ThingHappened" in out
-        assert "ThingHappeningsReport" in out
-        assert "SimpleKV" in out
+    def test_with_invalid_app(self):
+        with self.assertRaises(LookupError):
+            self.run_mgmt_command(djelme_backend_types, "notanapp")

--- a/elasticsearch_metrics/tests/test_registry.py
+++ b/elasticsearch_metrics/tests/test_registry.py
@@ -31,10 +31,7 @@ class TestTimeseriesTypeRegistry(SimpleTestCase):
 
         with self.assertRaises(LookupError) as excinfo:
             djelme_registry.get_recordtype("notanapp", "Dummy8Event")
-        assert (
-            "No recordtypes found in app with label 'notanapp'."
-            in excinfo.exception.args[0]
-        )
+        assert "'notanapp'" in excinfo.exception.args[0]
 
     def test_get_recordtypes(self):
         class AnotherRecord(elastic8.TimeseriesRecord):
@@ -50,10 +47,7 @@ class TestTimeseriesTypeRegistry(SimpleTestCase):
 
         with self.assertRaises(LookupError) as excinfo:
             list(djelme_registry.each_recordtype(app_label="notanapp"))
-        assert (
-            "No recordtypes found in app with label 'notanapp'."
-            in excinfo.exception.args[0]
-        )
+        assert "'notanapp'" in excinfo.exception.args[0]
 
     def test_get_recordtypes_excludes_abstract_recordtypes(self):
         class AbstractRecord(elastic8.TimeseriesRecord):
@@ -67,6 +61,6 @@ class TestTimeseriesTypeRegistry(SimpleTestCase):
         assert elastic8.BaseDjelmeRecord not in djelme_registry.each_recordtype()
         assert elastic8.TimeseriesRecord not in djelme_registry.each_recordtype()
         assert elastic8.EventRecord not in djelme_registry.each_recordtype()
-        assert elastic8.CyclicRecord not in djelme_registry.each_recordtype()
+        assert elastic8.CyclicReport not in djelme_registry.each_recordtype()
         assert AbstractRecord not in djelme_registry.each_recordtype()
         assert ConcreteRecord in djelme_registry.each_recordtype()

--- a/elasticsearch_metrics/tests/util.py
+++ b/elasticsearch_metrics/tests/util.py
@@ -37,9 +37,8 @@ class SimpleDjelmeTestCase(SimpleTestCase):
 
     def enterContext(self, context_manager):
         # unittest.TestCase.enterContext added in python3.11 -- implementing here until 3.10 eol
-        result = context_manager.__enter__()
         self.addCleanup(lambda: context_manager.__exit__(None, None, None))
-        return result
+        return context_manager.__enter__()
 
     def run_mgmt_command(
         self, cmd: str | BaseCommand | types.ModuleType, *args: str, **options: str

--- a/elasticsearch_metrics/util/__init__.py
+++ b/elasticsearch_metrics/util/__init__.py
@@ -1,5 +1,6 @@
 __all__ = (
     "anon_enough",
+    "timeparts",
     "timeseries_naming",
     "unique_together",
 )

--- a/elasticsearch_metrics/util/index_status.py
+++ b/elasticsearch_metrics/util/index_status.py
@@ -1,0 +1,7 @@
+import dataclasses
+
+
+@dataclasses.dataclass
+class DjelmeIndexStatus:
+    index_name: str
+    is_expired: bool = False

--- a/elasticsearch_metrics/util/timeparts.py
+++ b/elasticsearch_metrics/util/timeparts.py
@@ -1,124 +1,311 @@
-import collections
+import collections.abc as cabc
+import dataclasses
 import datetime
 import itertools
+import typing
 
 __all__ = (
-    "get_timeparts",
-    "timeparts_from_date",
-    "format_timeparts",
-    "format_full_timeparts",
-    "each_timepart_from_date",
+    "serialize_timeparts",
+    "parse_timeparts",
+    "Timeparts",
+    "AbstractTimeparts",
+    "TimepartStrat",
+    "GregorianTime",
+    "TIMEPART_DELIMITER",
 )
 
 TIMEPART_DELIMITER: str = "."
 
-
-def timeparts_from_date(given_date: datetime.date, timedepth: int) -> tuple[int, ...]:
-    """
-    >>> timeparts_from_date(datetime.date(3456, 7, 8), 2)
-    (3456, 7)
-    >>> timeparts_from_date(datetime.date(3456, 7, 8), 4)
-    (3456, 7, 8, 0)
-    """
-    return tuple(
-        itertools.islice(
-            _zeropadded_timeparts(each_timepart_from_date(given_date)),
-            timedepth,
-        )
-    )
+Timeparts = tuple[int, ...]
+AbstractTimeparts = cabc.Sequence[int]
 
 
-def each_timepart_from_date(given_date: datetime.date) -> collections.abc.Iterator[int]:
-    yield given_date.year
-    yield given_date.month
-    yield given_date.day
-    if isinstance(given_date, datetime.datetime):
-        yield given_date.hour
-        yield given_date.minute
-        yield given_date.second
+###
+# strategy-agnostic timepart functios
 
 
-def _zeropadded_timeparts(
-    timeparts: collections.abc.Iterable[int],
-) -> collections.abc.Iterator[int]:
-    yield from timeparts
-    yield from itertools.repeat(0)
-
-
-def get_timeparts(
-    when: tuple[int, ...] | datetime.date | str,
-    timedepth: int,
-) -> tuple[int, ...]:
-    if isinstance(when, datetime.date):
-        return timeparts_from_date(when, timedepth)
-    _each_part = parse_timeparts(when) if isinstance(when, str) else when
-    return tuple(itertools.islice(_zeropadded_timeparts(_each_part), timedepth))
-
-
-def format_full_timeparts(when: tuple[int, ...] | datetime.date) -> str:
-    """
-    >>> format_full_timeparts((3000, 2))
-    '3000.2'
-    >>> format_full_timeparts(datetime.date(3000, 7, 12))
-    '3000.7.12'
-    >>> format_full_timeparts(datetime.datetime(3000, 9, 1))
-    '3000.9.1.0.0.0'
-    """
-    _parts = (
-        timeparts_from_date(
-            when, timedepth=(6 if isinstance(when, datetime.datetime) else 3)
-        )
-        if isinstance(when, datetime.date)
-        else when
-    )
-    return TIMEPART_DELIMITER.join(map(str, _parts))
-
-
-def format_timeparts(
-    when: tuple[int, ...] | datetime.date | str, timedepth: int
+def serialize_timeparts(
+    when: AbstractTimeparts, max_timedepth: int | None = None
 ) -> str:
     """
-    >>> format_timeparts(datetime.date(3000, 7, 12), timedepth=3)
+    >>> serialize_timeparts((3000, 2))
+    '3000.2'
+    >>> serialize_timeparts((3000, 7, 12))
     '3000.7.12'
-    >>> format_timeparts(datetime.date(3000, 7, 12), timedepth=2)
-    '3000.7'
-    >>> format_timeparts(datetime.date(3000, 7, 12), timedepth=1)
+    >>> serialize_timeparts((3000, 9, 1, 0, 0, 0))
+    '3000.9.1.0.0.0'
+
+    truncates to max_timedepth
+    >>> serialize_timeparts((3000, 9, 1, 0, 0, 0), max_timedepth=3)
+    '3000.9.1'
+
+    does not pad
+    >>> serialize_timeparts((3000,), max_timedepth=5)
     '3000'
+
+    >>> serialize_timeparts(())
+    ''
     """
-    return format_full_timeparts(get_timeparts(when, timedepth))
+    assert all(isinstance(_part, int) for _part in when)
+    _each_part: cabc.Iterator[str] = map(str, when)
+    if max_timedepth is not None:
+        _each_part = itertools.islice(_each_part, max_timedepth)
+    return TIMEPART_DELIMITER.join(_each_part)
 
 
-def parse_timeparts(timepart_str: str) -> tuple[int, ...]:
+def parse_timeparts(timepart_str: str, max_timedepth: int | None = None) -> Timeparts:
     """
     >>> parse_timeparts('1.2.3')
     (1, 2, 3)
     >>> parse_timeparts('1999.12.7.9')
     (1999, 12, 7, 9)
+    >>> parse_timeparts('1999.12.7.9', max_timedepth=2)
+    (1999, 12)
     >>> parse_timeparts('')
     ()
+    >>> parse_timeparts('100.200.')
+    (100, 200)
     """
     _split_parts = timepart_str.split(TIMEPART_DELIMITER)
     if not any(_split_parts):
         return ()
-    return tuple(map(int, _split_parts))
+    _parsed = tuple(int(_part) for _part in _split_parts if _part)
+    return _parsed if max_timedepth is None else _parsed[:max_timedepth]
+
+
+def _each_timeparts_in_timerange(
+    from_timeparts: AbstractTimeparts,
+    until_timeparts: AbstractTimeparts,
+    *,
+    timedepth: int,
+    max_fanout: int,
+) -> cabc.Generator[Timeparts]:
+    """
+    yield timeparts
+    """
+    if timedepth <= 0:
+        yield ()  # reached timedepth
+        return
+    _from_part, *_from_rest = from_timeparts or [0]
+    _until_part, *_until_rest = until_timeparts or [0]
+    if _from_part == _until_part:
+        for _rest_parts in _each_timeparts_in_timerange(
+            _from_rest,
+            _until_rest,
+            timedepth=timedepth - 1,
+            max_fanout=max_fanout,
+        ):
+            yield (_from_part, *_rest_parts)
+    elif 0 < (_until_part - _from_part) <= max_fanout:  # not too far apart
+        for _parallel_part in range(_from_part, _until_part):
+            yield (_parallel_part,)
+        if any(_until_rest):  # some of the "until" bucket is included
+            _from_zero = tuple(itertools.repeat(0, len(_until_rest)))
+            for _rest_parts in _each_timeparts_in_timerange(
+                _from_zero,
+                _until_rest,
+                timedepth=timedepth - 1,
+                max_fanout=max_fanout,
+            ):
+                yield (_until_part, *_rest_parts)
+    else:  # too far apart
+        yield ()
+
+
+###
+# protocol for timepart strategies
+
+
+class TimepartStrat(typing.Protocol):
+    def get_timeparts(
+        self,
+        when: AbstractTimeparts | datetime.date | str,
+        pad: bool = True,
+        truncate: bool = True,
+    ) -> Timeparts: ...
+
+    def each_timeparts_in_timerange(
+        self,
+        from_timeparts: AbstractTimeparts,
+        until_timeparts: AbstractTimeparts,
+        *,
+        max_fanout: int,
+    ) -> cabc.Iterator[Timeparts]: ...
+
+    def with_default_timedepth(self, new_default_timedepth: int) -> "TimepartStrat": ...
+
+
+###
+# default TimepartStrat implementation
+
+
+@dataclasses.dataclass
+class GregorianTime(TimepartStrat):
+    default_timedepth: int
+    tz: datetime.tzinfo = datetime.timezone.utc
+
+    def get_timeparts(
+        self,
+        when: AbstractTimeparts | datetime.date | str,
+        pad: bool = True,
+        truncate: bool = True,
+    ) -> Timeparts:
+        """
+        >>> GregorianTime(2).get_timeparts(datetime.date(3456, 7, 8))
+        (3456, 7)
+        >>> GregorianTime(4).get_timeparts((3456,))
+        (3456, 1, 1, 0)
+        >>> GregorianTime(4).get_timeparts((3456,), pad=False)
+        (3456,)
+        >>> GregorianTime(4).get_timeparts(datetime.date(3456, 7, 8))
+        (3456, 7, 8, 0)
+        >>> GregorianTime(4).get_timeparts((3456, 7, 8, 9, 10, 11))
+        (3456, 7, 8, 9)
+        >>> GregorianTime(4).get_timeparts((3456, 7, 8, 9, 10, 11), truncate=False)
+        (3456, 7, 8, 9, 10, 11)
+        >>> GregorianTime(2).get_timeparts('3456.7.8.9')
+        (3456, 7)
+        >>> GregorianTime(2).get_timeparts('3456.7.8.9', pad=False, truncate=False)
+        (3456, 7, 8, 9)
+        >>> GregorianTime(4).get_timeparts('3456-07-08T09:10:11+00:00')
+        (3456, 7, 8, 9)
+        """
+        _parts: Timeparts
+        if isinstance(when, datetime.date):
+            _parts = tuple(self._each_timepart_from_date(when))
+        elif isinstance(when, str):
+            _parts = tuple(self._each_timepart_from_str(when))
+        elif isinstance(when, cabc.Sequence) and not isinstance(when, str):
+            _parts = tuple(when)
+        else:
+            raise ValueError("expected tuple, list, date, datetime, or str", when)
+        if pad and len(_parts) < self.default_timedepth:
+            _parts = tuple(
+                itertools.islice(
+                    self._each_timepart_with_defaults(_parts), self.default_timedepth
+                )
+            )
+        return _parts[: self.default_timedepth] if truncate else _parts
+
+    def each_timeparts_in_timerange(
+        self,
+        from_timeparts: AbstractTimeparts,
+        until_timeparts: AbstractTimeparts,
+        *,
+        max_fanout: int,
+    ) -> cabc.Iterator[Timeparts]:
+        """
+        yield timeparts that cover the given timerange
+
+        >>> list(GregorianTime(2).each_timeparts_in_timerange(
+        ...     (5020, 2, 2), (5020, 12, 20), max_fanout=3))
+        [(5020,)]
+        >>> list(GregorianTime(2).each_timeparts_in_timerange(
+        ...     (5020, 2, 2), (5020, 2, 20), max_fanout=3))
+        [(5020, 2)]
+
+        >>> list(GregorianTime(2).each_timeparts_in_timerange(
+        ...     (5020, 2, 2), (5020, 3, 20), max_fanout=3))
+        [(5020, 2), (5020, 3)]
+
+        >>> list(GregorianTime(2).each_timeparts_in_timerange(
+        ...     (5020, 2, 2), (6020, 12, 20), max_fanout=3))
+        [()]
+
+        >>> list(GregorianTime(3).each_timeparts_in_timerange(
+        ...     (5020, 2, 2), (5020, 3, 3), max_fanout=3))
+        [(5020, 2), (5020, 3, 1), (5020, 3, 2)]
+
+        >>> list(GregorianTime(3).each_timeparts_in_timerange(
+        ...     (5020, 2, 2), (5021, 3, 3), max_fanout=3))
+        [(5020,), (5021, 1), (5021, 2), (5021, 3, 1), (5021, 3, 2)]
+
+        >>> list(GregorianTime(3).each_timeparts_in_timerange(
+        ...     (5020, 2, 2), (5021, 3, 3), max_fanout=2))
+        [(5020,), (5021,)]
+
+        >>> list(GregorianTime(3).each_timeparts_in_timerange(
+        ...     (5020, 2, 2), (5021, 7, 3), max_fanout=3))
+        [(5020,), (5021,)]
+        """
+        for _timeparts in _each_timeparts_in_timerange(
+            from_timeparts,
+            until_timeparts,
+            timedepth=self.default_timedepth,
+            max_fanout=max_fanout,
+        ):
+            if 0 in _timeparts[1:3]:
+                continue  # skip month zero and day zero
+            yield _timeparts
+
+    def _each_timepart_from_str(self, given: str) -> cabc.Iterable[int]:
+        try:  # iso-formatted date, e.g. "YYYY-MM-DD"
+            _parsed_date = datetime.date.fromisoformat(given)
+        except ValueError:
+            pass
+        else:
+            return self._each_timepart_from_date(_parsed_date)
+        try:  # iso-formatted datetime, e.g. "YYYY-MM-DDTHH:MM:SSZ"
+            _parsed_datetime = datetime.datetime.fromisoformat(given)
+        except ValueError:
+            pass
+        else:
+            return self._each_timepart_from_date(_parsed_datetime.astimezone(self.tz))
+        # if not iso-formatted date(time), assume semverlike "X.Y.Z"
+        return parse_timeparts(given)
+
+    def _each_timepart_from_date(self, given_date: datetime.date) -> cabc.Iterator[int]:
+        yield given_date.year
+        yield given_date.month
+        yield given_date.day
+        if isinstance(given_date, datetime.datetime):
+            yield given_date.hour
+            yield given_date.minute
+            yield given_date.second
+
+    def _each_timepart_with_defaults(
+        self, timeparts: AbstractTimeparts
+    ) -> cabc.Iterator[int]:
+        for _i in range(3):  # guarantee at least year/month/day
+            try:
+                yield timeparts[_i]
+            except IndexError:
+                yield 1  # default 1 for year/month/day
+        # if present, hour/minute/second/microsecond
+        yield from timeparts[3:7]
+        # zero-pad forever
+        yield from itertools.repeat(0)
+
+    def with_default_timedepth(self, new_default_timedepth: int) -> TimepartStrat:
+        return dataclasses.replace(self, default_timedepth=new_default_timedepth)
 
 
 if __debug__:
     __test__ = {
-        "format_timeparts": """
->>> format_timeparts((3000, 2, 7, 9), timedepth=2)
+        "serialize_timeparts": """
+>>> serialize_timeparts((3000, 2, 7, 9), max_timedepth=2)
 '3000.2'
->>> format_timeparts((3000, 2), timedepth=1)
+>>> serialize_timeparts((3000, 2), max_timedepth=1)
 '3000'
->>> format_timeparts((3000, 2, 7, 9), timedepth=5)
-'3000.2.7.9.0'
->>> format_timeparts(datetime.datetime(3000, 9, 1, 5, 2), timedepth=6)
-'3000.9.1.5.2.0'
->>> format_timeparts(datetime.datetime(3000, 9, 1, 5, 2), timedepth=3)
-'3000.9.1'
->>> format_timeparts('3000.2.7.9', timedepth=3)
-'3000.2.7'
->>> format_timeparts('3000.2.7.9', timedepth=5)
-'3000.2.7.9.0'
+>>> serialize_timeparts((3000, 2, 7, 9), max_timedepth=5)
+'3000.2.7.9'
+""",
+        "get_timeparts": """
+>>> GregorianTime(6).get_timeparts(datetime.datetime(3000, 9, 1, 5, 2))
+(3000, 9, 1, 5, 2, 0)
+>>> GregorianTime(3).get_timeparts(datetime.datetime(3000, 9, 1, 5, 2))
+(3000, 9, 1)
+>>> GregorianTime(3).get_timeparts(datetime.datetime(3000, 9, 1, 5, 2), truncate=False)
+(3000, 9, 1, 5, 2, 0)
+>>> GregorianTime(6).get_timeparts(datetime.date(3000, 9, 1))
+(3000, 9, 1, 0, 0, 0)
+>>> GregorianTime(6).get_timeparts(datetime.date(3000, 9, 1), pad=False)
+(3000, 9, 1)
+>>> GregorianTime(3).get_timeparts('3000.2.7.9')
+(3000, 2, 7)
+>>> GregorianTime(5).get_timeparts('3000.2.7.9')
+(3000, 2, 7, 9, 0)
+>>> GregorianTime(5).get_timeparts('3000.2.7.9', pad=False)
+(3000, 2, 7, 9)
 """,
     }

--- a/elasticsearch_metrics/util/timeseries_naming.py
+++ b/elasticsearch_metrics/util/timeseries_naming.py
@@ -7,268 +7,281 @@ for naming timeseries indexes with lexical time coverage
 from __future__ import annotations
 
 __all__ = (
-    "format_index_name",
-    "format_index_name_for_date",
-    "format_index_pattern",
-    "format_index_pattern_for_range",
+    "TimeseriesIndexNaming",
+    "TimeseriesRangePattern",
     "format_namepart",
     "format_template_name",
 )
 
-import collections
+import collections.abc as cabc
+import dataclasses
 import datetime
-import itertools
+import typing
 
-from .timeparts import (
-    timeparts_from_date,
-    get_timeparts,
-    format_full_timeparts,
-    parse_timeparts,
+from elasticsearch_metrics.util.timeparts import (
     TIMEPART_DELIMITER,
+    TimepartStrat,
+    Timeparts,
+    AbstractTimeparts,
+    serialize_timeparts,
 )
 
 _DELIMITER: str = "_"
 _TEMPLATE_NAME_SUFFIX = "_template"
-_DEFAULT_PATTERN_FANOUT: int = 3
 
 
-TimeseriesIndexNamePattern = tuple[str, str, tuple[int, ...]]
+@dataclasses.dataclass(frozen=True)
+class TimeseriesIndexNaming:
+    """dataclass for naming an index in a timeseries
 
-
-def format_index_name(
-    app_label: str,
-    recordtype: str,
-    timeparts: str | collections.abc.Sequence[int] = (),  # empty () -- all time
-    max_timedepth: int | None = None,
-) -> str:
-    """get a full/specific index name, no wildcards or lists
-
-    >>> format_index_name('a', 'rt', (9999, 22))
+    >>> TimeseriesIndexNaming('a', 'rt', (9999, 22), GregorianTime(2))
+    TimeseriesIndexNaming(app_label='a',
+        recordtype='rt',
+        given_timeparts=(9999, 22),
+        timepart_strat=GregorianTime(default_timedepth=2, tz=datetime.timezone.utc),
+        prefix='')
+    >>> str(_)
     'a_rt_9999.22.'
-    >>> format_index_name('a', 'rt', (9999, 22, 0))
-    'a_rt_9999.22.0.'
-    >>> format_index_name('app', 'type', '500.2.3')
-    'app_type_500.2.3.'
-    >>> format_index_name('app', 'type', ())
-    'app_type_'
-    """
-    _parts = [
-        format_namepart(app_label),
-        format_namepart(recordtype),
-    ]
-    _timeparts_seq = (
-        parse_timeparts(timeparts) if isinstance(timeparts, str) else timeparts
-    )
-    if _timeparts_seq:
-        _trimmed_timeparts = (
-            _timeparts_seq
-            if (max_timedepth is None)
-            else _timeparts_seq[:max_timedepth]
-        )
-        _parts.append(_format_timename(*_trimmed_timeparts))
-    else:
-        _parts.append("")  # add trailing delimiter for unambiguous pattern matching
-    return _DELIMITER.join(_parts)
+    >>> str(TimeseriesIndexNaming('a', 'rt', (9999, 22, 1), GregorianTime(3)))
+    'a_rt_9999.22.1.'
 
+    given timepart strategy handles truncating or padding timeparts of unexpected length
+    >>> str(TimeseriesIndexNaming('a', 'rt', (1, 2, 3, 4, 5), GregorianTime(3)))
+    'a_rt_1.2.3.'
+    >>> str(TimeseriesIndexNaming('a', 'rt', (1, 2, 3), GregorianTime(5)))
+    'a_rt_1.2.3.0.0.'
 
-def format_index_name_for_date(
-    given_date: datetime.date,
-    *,
-    app_label: str,
-    recordtype: str,
-    timedepth: int,
-) -> str:
-    """get a full/specific index name, no wildcards or lists
-    >>> format_index_name_for_date(datetime.date(9876,5,4), app_label='ap', recordtype='rt', timedepth=2)
-    'ap_rt_9876.5.'
-    """
-    return format_index_name(
-        app_label, recordtype, timeparts_from_date(given_date, timedepth)
-    )
+    can give an index name `prefix`
+    >>> str(TimeseriesIndexNaming('a', 'rt', (9999,22,1,0), GregorianTime(2), prefix='prefix-'))
+    'prefix-a_rt_9999.22.'
 
-
-def format_index_pattern(
-    app_label: str,
-    recordtype: str,
-    timeparts: str | collections.abc.Sequence[int] = (),  # empty () -- all time
-    max_timedepth: int | None = None,
-) -> str:
-    """get an index-name pattern for all indexes within the given timeparts
-    >>> format_index_pattern('a', 'rt', (9999,22))
-    'a_rt_9999.22.*'
-    >>> format_index_pattern('a', 'rt', (1, 2, 3, 4, 5))
+    use `.to_str(wildcard=True)` to get a pattern matching all indexes within the given timeparts
+    >>> TimeseriesIndexNaming('a', 'rt', (1, 2, 3, 4, 5), GregorianTime(5)).to_str(wildcard=True)
     'a_rt_1.2.3.4.5.*'
-    >>> format_index_pattern('a', 'rt', (1, 2, 3, 4, 5), max_timedepth=3)
-    'a_rt_1.2.3.*'
-    >>> format_index_pattern('a', 'rt', '5.6.7.8', max_timedepth=3)
-    'a_rt_5.6.7.*'
-    >>> format_index_pattern('a', 'rt', ())
-    'a_rt_*'
+
+    can also give a date
+    >>> TimeseriesIndexNaming('ap', 'rt', datetime.date(9876,5,4), GregorianTime(2)).to_str()
+    'ap_rt_9876.5.'
+
+    or a semver-like timepart string
+    >>> TimeseriesIndexNaming('a', 'rt', '5.6.7.8', GregorianTime(3), prefix='hello_').to_str(wildcard=True)
+    'hello_a_rt_5.6.7.*'
     """
-    return f"{format_index_name(app_label, recordtype, timeparts, max_timedepth)}*"
 
+    app_label: str
+    recordtype: str
+    given_timeparts: AbstractTimeparts | datetime.date | str
+    timepart_strat: TimepartStrat
+    prefix: str = ""
 
-def _each_timeparts_for_timerange(
-    from_timeparts: collections.abc.Sequence[int],
-    until_timeparts: collections.abc.Sequence[int],
-    *,
-    timedepth: int,
-    max_fanout: int,
-    include_less_timedepth: bool,
-) -> collections.abc.Generator[tuple[tuple[int, ...], bool]]:
-    """
-    yield (timeparts, is_wildcard) tuples
-    """
-    if timedepth <= 0:
-        yield (), True  # reached timedepth; wildcard
-        return
-    _from_part, *_from_rest = from_timeparts or [0]
-    _until_part, *_until_rest = until_timeparts or [0]
-    if include_less_timedepth:
-        yield (), False  # include less-granular non-wildcard index, if it exists
-    if _from_part == _until_part:
-        for _rest_parts, _is_wildcard in _each_timeparts_for_timerange(
-            _from_rest,
-            _until_rest,
-            timedepth=timedepth - 1,
-            max_fanout=max_fanout,
-            include_less_timedepth=include_less_timedepth,
-        ):
-            yield (_from_part, *_rest_parts), _is_wildcard
-    elif 0 < (_until_part - _from_part) <= max_fanout:  # not too far apart
-        for _parallel_part in range(_from_part, _until_part):
-            yield (_parallel_part,), True  # wildcard
-        if any(_until_rest):  # some of the "until" bucket is included
-            _from_zero = tuple(itertools.repeat(0, len(_until_rest)))
-            for _rest_parts, _is_wildcard in _each_timeparts_for_timerange(
-                _from_zero,
-                _until_rest,
-                timedepth=timedepth - 1,
-                max_fanout=max_fanout,
-                include_less_timedepth=include_less_timedepth,
-            ):
-                yield (_until_part, *_rest_parts), _is_wildcard
-    else:  # too far apart
-        yield (), True  # wildcard
+    @classmethod
+    def parse(
+        cls,
+        index_name: str,
+        timepart_strat: TimepartStrat,
+        *,
+        prefix: str = "",
+    ) -> typing.Self:
+        """construct a TimeseriesIndexNaming by parsing an index name
 
+        >>> TimeseriesIndexNaming.parse('myapp_myrecord_2000.12.1.', GregorianTime(3))
+        TimeseriesIndexNaming(app_label='myapp',
+            recordtype='myrecord',
+            given_timeparts='2000.12.1.',
+            timepart_strat=GregorianTime(default_timedepth=3, tz=datetime.timezone.utc),
+            prefix='')
+        >>> _.timeparts
+        (2000, 12, 1)
 
-def _each_indexpattern_for_timerange(
-    app_label: str,
-    recordtype: str,
-    from_timeparts: collections.abc.Sequence[int],
-    until_timeparts: collections.abc.Sequence[int],
-    *,
-    timedepth: int,
-    max_fanout: int,
-    include_less_timedepth: bool,
-    only_datelike: bool,
-) -> collections.abc.Generator[str]:
-    for _timeparts, _is_wildcard in _each_timeparts_for_timerange(
-        from_timeparts,
-        until_timeparts,
-        timedepth=timedepth,
-        max_fanout=max_fanout,
-        include_less_timedepth=include_less_timedepth,
-    ):
-        if only_datelike and (0 in _timeparts[1:3]):
-            # intuitively, zero is a fine value for any datepart except the second and third
-            continue  # skip month zero and day zero
-        if _is_wildcard:
-            yield format_index_pattern(app_label, recordtype, _timeparts)
+        can also give an expected `prefix` to remove
+        >>> TimeseriesIndexNaming.parse(
+        ...     'prefixmyapp_myrecord_2000.12.2.',
+        ...     GregorianTime(3),
+        ...     prefix='prefix',
+        ... )
+        TimeseriesIndexNaming(app_label='myapp',
+            recordtype='myrecord',
+            given_timeparts='2000.12.2.',
+            timepart_strat=GregorianTime(default_timedepth=3, tz=datetime.timezone.utc),
+            prefix='prefix')
+        >>> _.timeparts
+        (2000, 12, 2)
+        """
+        if not index_name.startswith(prefix):
+            raise ValueError(f"expected prefix {prefix!r} on index name {index_name!r}")
+        _trimmed_name = index_name.removeprefix(prefix)
+        try:
+            _app_label, _recordtype, _timeparts = _trimmed_name.split(_DELIMITER)
+        except ValueError as _err:
+            raise ValueError(
+                "expected index name format applabel_recordtype_timeparts",
+                _trimmed_name,
+            ) from _err
+        return cls(
+            _app_label,
+            _recordtype,
+            _timeparts,
+            timepart_strat,
+            prefix=prefix,
+        )
+
+    @property
+    def timeparts(self) -> Timeparts:
+        # neither truncate nor pad, just parse as given
+        return self.timepart_strat.get_timeparts(
+            self.given_timeparts, pad=False, truncate=False
+        )
+
+    @property
+    def timeparts_for_naming(self) -> Timeparts:
+        # when naming an index, truncate or pad to the default timedepth
+        return self.timepart_strat.get_timeparts(self.given_timeparts)
+
+    @property
+    def timeparts_for_wildcard(self) -> Timeparts:
+        # for wildcards, do truncate but do not pad
+        return self.timepart_strat.get_timeparts(self.given_timeparts, pad=False)
+
+    def __str__(self) -> str:
+        """get the name of a specific index, no wildcard"""
+        return self.to_str()
+
+    def to_str(self, *, wildcard: bool = False) -> str:
+        """get the name of an index or a wildcard pattern"""
+        _parts = [
+            format_namepart(self.app_label),
+            format_namepart(self.recordtype),
+        ]
+        _timeparts = (
+            self.timeparts_for_wildcard if wildcard else self.timeparts_for_naming
+        )
+        if _timeparts:
+            _parts.append(_format_timename(_timeparts))
         else:
-            yield format_index_name(app_label, recordtype, _timeparts)
+            _parts.append("")  # add trailing delimiter for unambiguous pattern matching
+        _base_name = _DELIMITER.join(_parts)
+        _suffix = "*" if wildcard else ""
+        return f"{self.prefix}{_base_name}{_suffix}"
 
 
-def format_index_pattern_for_timeparts_range(
-    app_label: str,
-    recordtype: str,
-    from_timeparts: collections.abc.Sequence[int],
-    until_timeparts: collections.abc.Sequence[int],
-    *,
-    timedepth: int,
-    max_fanout: int = _DEFAULT_PATTERN_FANOUT,
-    include_less_timedepth: bool = False,
-    only_datelike: bool = False,
-) -> str:
-    """get an index-name pattern for all indexes within a timepart range
+@dataclasses.dataclass(frozen=True)
+class TimeseriesRangePattern:
+    """dataclass for a wildcard pattern matching all index names within a time range
 
-    choose a wildcard based on shared timeparts
-    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
-    ...     (5020, 2, 2), (5020, 12, 20), timedepth=2)
+    >>> TimeseriesRangePattern(
+    ...     app_label='ap',
+    ...     recordtype='rt',
+    ...     from_when=(5020, 2, 2),
+    ...     until_when=(5020, 12, 20),
+    ...     timepart_strat=GregorianTime(2),
+    ... )
+    TimeseriesRangePattern(app_label='ap', recordtype='rt',
+        from_when=(5020, 2, 2), until_when=(5020, 12, 20),
+        timepart_strat=GregorianTime(default_timedepth=2, tz=datetime.timezone.utc),
+        index_name_prefix='', max_fanout=3)
+
+    use `.to_str()` to get the full pattern -- may be a simple wildcard with shared timeparts
+    >>> TimeseriesRangePattern('ap', 'rt',
+    ...     (5020, 2, 2), (5020, 12, 20), GregorianTime(2)).to_str()
     'ap_rt_5020.*'
-    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
-    ...     (5020, 2, 2), (5020, 2, 20), timedepth=2)
+    >>> TimeseriesRangePattern('ap', 'rt',
+    ...     (5020, 2, 2), (5020, 2, 20), GregorianTime(2)).to_str()
     'ap_rt_5020.2.*'
 
-    if unshared timeparts close enough, enumerate possibilities to narrow the wildcard
-    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
-    ...     (5020, 2, 2), (5020, 3, 3), timedepth=3)
-    'ap_rt_5020.2.*,ap_rt_5020.3.0.*,ap_rt_5020.3.1.*,ap_rt_5020.3.2.*'
+    or, if unshared timeparts close enough, enumerate possibilities to narrow the wildcard
+    >>> TimeseriesRangePattern('ap', 'rt',
+    ...     (5020, 2, 2), (5020, 3, 3), GregorianTime(3)).to_str()
+    'ap_rt_5020.2.*,ap_rt_5020.3.1.*,ap_rt_5020.3.2.*'
 
-    with `only_datelike=True`, exclude patterns with zero in "month" or "day"
-    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
-    ...     (5020, 2, 2), (5022, 3, 3), timedepth=3, only_datelike=True)
-    'ap_rt_5020.*,ap_rt_5021.*,ap_rt_5022.1.*,ap_rt_5022.2.*,ap_rt_5022.3.1.*,ap_rt_5022.3.2.*'
+    `max_fanout` controls what's "close enough" to enumerate
+    >>> _fanout_example = TimeseriesRangePattern('ap', 'rt',
+    ...     (5020, 2, 2), (5020, 3, 5), GregorianTime(3), max_fanout=0)
+    >>> _fanout_example.to_str()
+    'ap_rt_5020.*'
+    >>> dataclasses.replace(_fanout_example, max_fanout=1).to_str()
+    'ap_rt_5020.2.*,ap_rt_5020.3.*'
+    >>> dataclasses.replace(_fanout_example, max_fanout=7).to_str()
+    'ap_rt_5020.2.*,ap_rt_5020.3.1.*,ap_rt_5020.3.2.*,ap_rt_5020.3.3.*,ap_rt_5020.3.4.*'
 
-    with `include_less_timedepth=True`, include patterns for indexes created with lower timedepths
-    >>> format_index_pattern_for_timeparts_range('ap', 'rt',
-    ...     (5020, 2, 2), (5020, 2, 20), timedepth=2, include_less_timedepth=True)
-    'ap_rt_,ap_rt_5020.,ap_rt_5020.2.*'
-    """
-    return ",".join(
-        _each_indexpattern_for_timerange(
-            app_label,
-            recordtype,
-            from_timeparts,
-            until_timeparts,
-            timedepth=timedepth,
-            max_fanout=max_fanout,
-            include_less_timedepth=include_less_timedepth,
-            only_datelike=only_datelike,
-        )
-    )
+    with `.to_str(include_less_timedepth=True)`, include patterns for indexes created with lower timedepths
+    >>> TimeseriesRangePattern('ap', 'rt',
+    ...     (5020, 2, 2), (5020, 2, 20), GregorianTime(2)).to_str(include_less_timedepth=True)
+    'ap_rt_5020.2.*,ap_rt_,ap_rt_5020.'
 
-
-def format_index_pattern_for_range(
-    app_label: str,
-    recordtype: str,
-    from_when: tuple[int, ...] | datetime.date,
-    until_when: tuple[int, ...] | datetime.date,
-    timedepth: int,
-    include_less_timedepth: bool = False,
-) -> str:
-    """get an index-name pattern for all indexes within a date range
-
-    >>> format_index_pattern_for_range('ap', 'rt',
-    ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 8),
-    ...     timedepth=2)
+    can also give dates
+    >>> TimeseriesRangePattern('ap', 'rt',
+    ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 7),
+    ...     GregorianTime(2)).to_str()
     'ap_rt_2050.5.*'
-    >>> format_index_pattern_for_range('ap', 'rt',
-    ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 8),
-    ...     timedepth=2, include_less_timedepth=True)
-    'ap_rt_,ap_rt_2050.,ap_rt_2050.5.*'
-    >>> format_index_pattern_for_range('ap', 'rt',
-    ...     datetime.date(2050, 5, 5), (2050, 5, 8, 10),
-    ...     timedepth=3)
-    'ap_rt_2050.5.5.*,ap_rt_2050.5.6.*,ap_rt_2050.5.7.*'
-    >>> format_index_pattern_for_range('ap', 'rt',
-    ...     (2050, 5, 5, 3), datetime.date(2050, 5, 8),
-    ...     timedepth=3, include_less_timedepth=True)
-    'ap_rt_,ap_rt_2050.,ap_rt_2050.5.,ap_rt_2050.5.5.*,ap_rt_2050.5.6.*,ap_rt_2050.5.7.*'
-    >>> format_index_pattern_for_range('ap', 'rt',
-    ...     (200, 5), datetime.date(200, 5, 8),
-    ...     timedepth=3)
-    'ap_rt_200.5.*'
+
+    can give `index_name_prefix` to add a prefix to each part
+    >>> TimeseriesRangePattern('ap', 'rt',
+    ...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 7),
+    ...     GregorianTime(3), index_name_prefix='blarg_').to_str()
+    'blarg_ap_rt_2050.5.5.*,blarg_ap_rt_2050.5.6.*'
     """
-    return format_index_pattern_for_timeparts_range(
-        app_label=app_label,
-        recordtype=recordtype,
-        from_timeparts=get_timeparts(from_when, timedepth),
-        until_timeparts=get_timeparts(until_when, timedepth),
-        timedepth=timedepth,
-        include_less_timedepth=include_less_timedepth,
-        only_datelike=True,
-    )
+
+    app_label: str
+    recordtype: str
+    from_when: AbstractTimeparts | datetime.date
+    until_when: AbstractTimeparts | datetime.date
+    timepart_strat: TimepartStrat
+    index_name_prefix: str = ""
+    max_fanout: int = 3
+
+    @property
+    def from_timeparts(self) -> Timeparts:
+        return self.timepart_strat.get_timeparts(self.from_when)
+
+    @property
+    def until_timeparts(self) -> Timeparts:
+        return self.timepart_strat.get_timeparts(self.until_when)
+
+    def __str__(self) -> str:
+        """get the pattern as a string (no index-name prefix)"""
+        return self.to_str()
+
+    def to_str(self, *, include_less_timedepth: bool = False) -> str:
+        """get the pattern as a string, with optional index-name prefix"""
+        return ",".join(
+            self.each_name_in_timerange(include_less_timedepth=include_less_timedepth)
+        )
+
+    def each_name_in_timerange(
+        self, *, include_less_timedepth: bool = False
+    ) -> cabc.Iterator[str]:
+        _lesser_timepartsen: set[Timeparts] = set()
+        for _timeparts in self.timepart_strat.each_timeparts_in_timerange(
+            self.from_timeparts,
+            self.until_timeparts,
+            max_fanout=self.max_fanout,
+        ):
+            yield self._get_naming(_timeparts).to_str(wildcard=True)
+            if include_less_timedepth:
+                _lesser_timepartsen.update(
+                    _timeparts[:_i] for _i in range(len(_timeparts))
+                )
+        for _lesser_timeparts in sorted(_lesser_timepartsen):
+            # non-wildcards, to include indexes created with less timedepth
+            yield str(self._get_naming(_lesser_timeparts, exact_timedepth=True))
+
+    def _get_naming(
+        self,
+        timeparts: Timeparts,
+        *,
+        exact_timedepth: bool = False,
+    ) -> TimeseriesIndexNaming:
+        return TimeseriesIndexNaming(
+            self.app_label,
+            self.recordtype,
+            timeparts,
+            timepart_strat=(
+                self.timepart_strat.with_default_timedepth(len(timeparts))
+                if exact_timedepth
+                else self.timepart_strat
+            ),
+            prefix=self.index_name_prefix,
+        )
 
 
 def format_template_name(
@@ -288,45 +301,72 @@ def format_namepart(namepart: str) -> str:
     return namepart.replace(_DELIMITER, "").lower()
 
 
-def _format_timename(*timeparts: int) -> str:
+def _format_timename(timeparts: AbstractTimeparts) -> str:
     """
-    >>> _format_timename(1999)
+    >>> _format_timename((1999,))
     '1999.'
-    >>> _format_timename(2345)
+    >>> _format_timename((2345,))
     '2345.'
 
     use with any series of integers
-    >>> _format_timename(1234, 5, 6, 7)
+    >>> _format_timename((1234, 5, 6, 7))
     '1234.5.6.7.'
-    >>> _format_timename(2345, 6, 2, 17, 4200)
+    >>> _format_timename((2345, 6, 2, 17, 4200))
     '2345.6.2.17.4200.'
-    >>> _format_timename(6, 1, 8, 2)
+    >>> _format_timename((6, 1, 8, 2))
     '6.1.8.2.'
-    >>> _format_timename(2345, 0)
+    >>> _format_timename((2345, 0))
     '2345.0.'
     """
-    return f"{format_full_timeparts(timeparts)}{TIMEPART_DELIMITER}"
+    return f"{serialize_timeparts(timeparts)}{TIMEPART_DELIMITER}"
 
 
 if __debug__:
+    from elasticsearch_metrics.util.timeparts import (  # noqa: F401 (for use in doctests)
+        GregorianTime,
+    )
+
     __test__ = {
-        "format_index_pattern_for_timeparts_range": """
->>> format_index_pattern_for_timeparts_range('ap', 'rt',
-...     (5020, 2, 1), (5020, 3), timedepth=2)
+        "more name formatting combinations": """
+>>> TimeseriesIndexNaming('app', 'type', '500.2.3', GregorianTime(3)).to_str()
+'app_type_500.2.3.'
+>>> TimeseriesIndexNaming('app', 'type', (), GregorianTime(0)).to_str()
+'app_type_'
+>>> TimeseriesIndexNaming('a', 'rt', (1, 2, 3, 4, 5), GregorianTime(3)).to_str(wildcard=True)
+'a_rt_1.2.3.*'
+>>> TimeseriesIndexNaming('a', 'rt', (), GregorianTime(2)).to_str(wildcard=True)
+'a_rt_*'
+""",
+        "more pattern formatting combinations": """
+>>> TimeseriesRangePattern('ap', 'rt',
+...     (5020, 2, 1), (5020, 3), GregorianTime(2)).to_str()
 'ap_rt_5020.2.*'
->>> format_index_pattern_for_timeparts_range('ap', 'rt',
-...     (5020, 2, 2), (5020, 2, 3), timedepth=3)
-'ap_rt_5020.2.2.*'
->>> format_index_pattern_for_timeparts_range('ap', 'rt',
-...     (5020, 2, 2), (5022,), timedepth=3)
-'ap_rt_5020.*,ap_rt_5021.*'
->>> format_index_pattern_for_timeparts_range('a', 'b', (1999,), (2002,), timedepth=2)
+>>> TimeseriesRangePattern('ap', 'rt',
+...     (5020, 2, 2), (5020, 2, 3), GregorianTime(3), index_name_prefix='blarg').to_str()
+'blargap_rt_5020.2.2.*'
+>>> TimeseriesRangePattern('a', 'b', (1999,), (2002,), GregorianTime(2)).to_str()
 'a_b_1999.*,a_b_2000.*,a_b_2001.*'
->>> format_index_pattern_for_timeparts_range('a', 'b',
-...     (1999, 27, 17, 0, 3), (1999, 27, 17, 0, 223,), timedepth=5)
+>>> TimeseriesRangePattern('a', 'b',
+...     (1999, 27, 17, 0, 3), (1999, 27, 17, 0, 223,), GregorianTime(5)).to_str()
 'a_b_1999.27.17.0.*'
->>> format_index_pattern_for_timeparts_range('a', 'b',
-...     (1999, 27, 17, 0, 3), (2002, 117, 17, 0, 3), timedepth=5)
+>>> TimeseriesRangePattern('a', 'b',
+...     (1999, 27, 17, 0, 3), (2002, 117, 17, 0, 3), GregorianTime(5)).to_str()
 'a_b_1999.*,a_b_2000.*,a_b_2001.*,a_b_2002.*'
+>>> TimeseriesRangePattern('ap', 'rt',
+...     datetime.date(2050, 5, 5), datetime.date(2050, 5, 8),
+...     GregorianTime(2), index_name_prefix='blag-').to_str(include_less_timedepth=True)
+'blag-ap_rt_2050.5.*,blag-ap_rt_,blag-ap_rt_2050.'
+>>> TimeseriesRangePattern('ap', 'rt',
+...     datetime.date(2050, 5, 5), (2050, 5, 8, 10),
+...     GregorianTime(3)).to_str()
+'ap_rt_2050.5.5.*,ap_rt_2050.5.6.*,ap_rt_2050.5.7.*'
+>>> TimeseriesRangePattern('ap', 'rt',
+...     (2050, 5, 5, 3), datetime.date(2050, 5, 8),
+...     GregorianTime(3)).to_str(include_less_timedepth=True)
+'ap_rt_2050.5.5.*,ap_rt_2050.5.6.*,ap_rt_2050.5.7.*,ap_rt_,ap_rt_2050.,ap_rt_2050.5.'
+>>> TimeseriesRangePattern('ap', 'rt',
+...     (200, 5), datetime.date(200, 5, 8),
+...     GregorianTime(3)).to_str()
+'ap_rt_200.5.*'
 """,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-elasticsearch-metrics"
-version = "2026.0.5"
+version = "2026.0.6"
 description = "Django app for storing time-series metrics in Elasticsearch."
 authors = [
     {name = "CenterForOpenScience", email = "support@cos.io"}


### PR DESCRIPTION
- rework elasticsearch_metrics.util.timeparts with a strategy
- rework elasticsearch_metrics.util.timeseries_naming for cleaner parsing
- add timeseries-index expiration
- add djelme_indexes management command
- add expiration tests
- update docs
- assorted tidying
- bump version to 2026.0.6